### PR TITLE
Add OCI labels so the GHCR package links back to the repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,14 @@ RUN touch src/main.rs src/lib.rs && cargo build --release
 ########################################################################
 FROM debian:trixie-slim AS runtime
 
+# OCI metadata. Without org.opencontainers.image.source a GHCR package has no link back to
+# its repository, shows no README and no licence, and cannot inherit the repo's visibility
+# — it just appears as an orphan under the org.
+LABEL org.opencontainers.image.source="https://github.com/terraops-org/TerraServe" \
+      org.opencontainers.image.description="Clean-room raster + vector map tile server in Rust — WMS/WMTS/TMS/MVT, no GDAL." \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later" \
+      org.opencontainers.image.title="TerraServe"
+
 # Runtime deps:
 #   - libproj25       : the PROJ shared library the binary dynamically links against
 #   - proj-data       : PROJ's transformation grids + proj.db — needed for CRS lookups/datum


### PR DESCRIPTION
Without `org.opencontainers.image.source`, a GHCR package is an orphan under the org: no link to its repository, no README, no licence shown, and it cannot inherit the repository's visibility.

Adds `source`, `description`, `licenses` (AGPL-3.0-or-later) and `title` to the runtime stage.

**This does not make the package public.** GHCR packages default to private even for a public repository, and GitHub exposes no REST endpoint for package visibility — that stays a one-time change under **Packages → terraserve → Package settings → Change visibility**.

Verified after the first publish run: all three jobs (amd64, arm64, manifest + smoke test) succeeded, but an anonymous `docker pull ghcr.io/terraops-org/terraserve:edge` returns `unauthorized`, which is the private-package signature.