### PR TITLE
fix(xray): default to the server's first layer, not the literal "vector"

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -796,10 +796,21 @@ async fn viewer_handler(State(state): State<Arc<ServeState>>) -> Response {
 /// page (`xray.html`, embedded at compile time — no per-request templating needed): it reads the
 /// `{layer}`/`{tms}` to display from the `?layer=`/`?tms=` query string client-side and requests
 /// tiles straight from `/mvt/{layer}/{tms}/{z}/{x}/{y}.pbf`, so no `ServeState` is needed here.
-async fn xray_handler() -> Response {
+async fn xray_handler(State(state): State<Arc<ServeState>>) -> Response {
+    // Substitute the server's FIRST layer as the viewer's default. Without this the page
+    // defaulted to the literal "vector" and every tile 404'd whenever the layer was named
+    // anything else (`--name airports` on the published demo image, for instance) — the
+    // viewer loaded, then failed to fetch a single tile, which reads as a broken server.
+    let default_layer = state
+        .layers
+        .first()
+        .map(|l| l.name.as_str())
+        .unwrap_or("vector");
     Response::builder()
         .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
-        .body(Body::from(xray_html()))
+        .body(Body::from(
+            xray_html().replace("__TS_DEFAULT_LAYER__", default_layer),
+        ))
         .unwrap()
 }
 

--- a/src/xray.html
+++ b/src/xray.html
@@ -238,7 +238,12 @@
 // pyramid (z0 = 1x1 tile, doubling per level), so no custom tileGrid/tileUrlFunction is needed —
 // unlike WorldCRS84Quad, which needs its own projection wiring (see /viewer for that case).
 var params = new URLSearchParams(location.search);
-var layerParam = params.get('layer') || params.get('layers') || 'vector';
+// The default is substituted by the server with its FIRST published layer (see
+// server.rs xray_handler). It used to be the literal 'vector', which broke the viewer
+// on any server whose layer was named anything else: tiles 404'd because /xray asked
+// for /mvt/vector/... while the layer was, say, 'airports'. The token below is replaced
+// at request time; it stays as a working fallback if substitution ever fails.
+var layerParam = params.get('layer') || params.get('layers') || '__TS_DEFAULT_LAYER__';
 var layerNames = layerParam.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
 var tms = params.get('tms') || 'WebMercatorQuad';
 


### PR DESCRIPTION
Reported against the published image: **`/xray` shows tile errors while `/viewer` works.**

### Root cause

The X-ray viewer defaulted its layer name to the hardcoded string `"vector"`, so it requested `/mvt/vector/{tms}/{z}/{x}/{y}.pbf` regardless of what the server actually published:

```
/mvt/airports/WebMercatorQuad/2/1/1.pbf   -> 200   ← the data is fine
/mvt/vector/WebMercatorQuad/2/1/1.pbf     -> 404   ← what /xray asked for
```

This image's `CMD` passes `--name airports` so `GetCapabilities` advertises a guessable layer instead of "vector" — which broke the viewer. The page loaded and then fetched nothing, which reads as a broken server rather than a naming mismatch. `/viewer` was unaffected because it's the raster path and doesn't use that name.

### Fix

`xray.html` is embedded at compile time and was served raw ("no per-request templating needed"), so the page had no way to know the server's layer names. It now carries a `__TS_DEFAULT_LAYER__` token that `xray_handler` substitutes with `state.layers[0].name`; the handler takes `State<Arc<ServeState>>` for the first time. The token remains a working fallback if substitution ever fails.

**This is a general fix, not a workaround for this image.** Any deployment whose layer isn't literally called `vector` hit it — which is every real deployment. The public demos only work because their proxy routes inject `?layer=` explicitly.

### Verification

- `/xray` now emits `params.get('layers') || 'airports'`
- the tile URL it derives returns **200**
- no un-substituted token remains in the served HTML
- `score.sh`: **39/39 required, 2/2 optional**