### PR TITLE
docs(readme): warmer tone, drop every em-dash, fix retired .html links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # TerraServe
 
-**A clean-room map tile engine in Rust — no GDAL, no MapServer, no GeoServer.**
+**A clean-room map tile engine in Rust. No GDAL, no MapServer, no GeoServer.**
 
-TerraServe reads Cloud-Optimized GeoTIFFs and GeoPackage / FlatGeoBuf / GeoJSON vectors,
-reprojects and rasterizes the window you ask for, styles it, and serves it over **WMS · WMTS · TMS ·
-vector tiles (MVT) · PMTiles** — with none of the usual stack underneath. Every file reader, the
+TerraServe reads Cloud-Optimized GeoTIFFs and GeoPackage, FlatGeoBuf or GeoJSON vectors, reprojects
+and rasterizes just the window you ask for, styles it, and serves it over **WMS · WMTS · TMS ·
+vector tiles (MVT) · PMTiles**, with none of the usual stack underneath. Every file reader, the
 reprojection plumbing, the tiling, the styling and the OGC protocol layer are written from scratch.
-The result is small, predictable in memory (a request's buffers are freed the instant it returns —
-no GC, no caches that grow forever), and certifiable against the OGC standards.
+The result is small, kind to your memory (a request's buffers are freed the instant it returns: no
+garbage collector, no caches that grow forever), and certifiable against the OGC standards.
 
 [![License: MPL-2.0](https://img.shields.io/badge/license-MPL--2.0-blue)](LICENSE) · **OGC CITE WMS 1.3.0: 135 / 0** (certifiable) · **Rust**
 
@@ -15,7 +15,8 @@ no GC, no caches that grow forever), and certifiable against the OGC standards.
 
 ## Get it running
 
-**Docker** build the image and serve a dataset. Point QGIS at `http://localhost:8080/wms`, or open the viewer at `http://localhost:8080/viewer`:
+The quickest path is Docker. Build the image, serve a dataset, then point QGIS at
+`http://localhost:8080/wms`, or open the viewer at `http://localhost:8080/viewer`:
 
 ```bash
 docker build -t terraserve .
@@ -23,77 +24,78 @@ docker run -p 8080:8080 -v "$PWD/data:/data:ro" terraserve \
   serve --cog /data/ortho.cog.tif --style /data/rgb.json --host 0.0.0.0 --port 8080
 ```
 
-**From source** (Rust, needs `libproj`):
+Prefer to build **from source**? You will need Rust and `libproj`:
 
 ```bash
 cargo build --release
 ./target/release/terraserve serve --cog ortho.cog.tif --style fixtures/styles/rgb.json --port 8080
-cargo test && ./score.sh    # tests + banned-crate gate + fixture regression → 39/39 (+2/2 optional)
+cargo test && ./score.sh    # tests + banned-crate gate + fixture regression, expect 39/39 (+2/2 optional)
 ```
 
 To serve **vector** data instead of a raster, swap `--cog`/`--style` for `--vector`/`--vec-style`
-(see the [CLI](#cli) below). Full flag reference + pitfalls: **[terraserve.io/docs](https://terraserve.io/docs.html)**.
+(see the [CLI](#cli) below). The full flag reference and the pitfalls worth knowing are at
+**[terraserve.io/docs](https://terraserve.io/docs)**.
 
 ## Why it's different
 
-- **No GDAL.** The whole server is a ~150 MB container with no heavyweight geospatial dependency —
-  about a quarter the size of the alternatives, and free of the library that is the usual cause of
-  the "my map server ate all the RAM and crashed" story.
+- **No GDAL.** The whole server is a ~150 MB container with no heavyweight geospatial dependency,
+  about a quarter the size of the alternatives, and free of the library behind most "my map server
+  ate all the RAM and crashed" stories.
 - **Bounded memory.** Under a burst it holds a firm ceiling and hands memory back when the rush
   passes. Admission control queues excess work instead of piling it up in RAM.
-- **Windowed reads.** Point it at a multi-gigabyte file and it opens in *megabytes* — it reads only
-  the piece under the current view, not the whole file (a 3.8 GB / 14.9 M-feature dataset opens in
-  ~4 MB).
+- **Windowed reads.** Point it at a multi-gigabyte file and it opens in *megabytes*, because it reads
+  only the piece under the current view, not the whole file (a 3.8 GB, 14.9 M-feature dataset opens
+  in about 4 MB).
 - **Honest about speed.** On live vector rendering it is *on par* with MapServer 8.6 on throughput and
-  ahead of GeoServer — and it holds a far tighter **tail latency under burst** (where a fixed worker
-  pool falls off a cliff), from a fraction of the memory and image size. Full results:
+  ahead of GeoServer, and it holds a far tighter **tail latency under burst** (where a fixed worker
+  pool falls off a cliff), from a fraction of the memory and image size. Full results at
   [terraserve.io](https://terraserve.io/#bench).
-- **Certifiable.** OGC CITE WMS 1.3.0 = **135 / 0** (`areCoreConformanceClassesPassed = true`),
-  WMS 1.1.1 core-certifiable — parity with MapServer / GeoServer / QGIS Server.
+- **Certifiable.** OGC CITE WMS 1.3.0 = **135 / 0** (`areCoreConformanceClassesPassed = true`), and
+  WMS 1.1.1 is core-certifiable, on par with MapServer, GeoServer and QGIS Server.
 
 ## Live demos
 
-Three real datasets on a small server, each exercising a different part of the engine — see
+Three real datasets on a small server, each exercising a different part of the engine. Have a look at
 [terraserve.io/examples](https://terraserve.io/examples/):
 
-- **cos2023** — Portugal's official land cover (842 k shapes): shared-border simplification + pre-baked tiles.
-- **vida** — 14.9 M building outlines across Iberia: windowed reads + precomputed low zoom.
-- **ndvi** — vegetation health computed **live** per tile from raw Sentinel-2 bands, no pre-made image.
+- **cos2023**: Portugal's official land cover (842 k shapes), with shared-border simplification and pre-baked tiles.
+- **vida**: 14.9 M building outlines across Iberia, via windowed reads and precomputed low zoom.
+- **ndvi**: vegetation health computed **live** per tile from raw Sentinel-2 bands, with no pre-made image.
 
 ## Sample data
 
-TerraServe ships **no datasets** — any Cloud-Optimized GeoTIFF or GeoPackage / FlatGeoBuf / GeoJSON
+TerraServe ships **no datasets**. Any Cloud-Optimized GeoTIFF or GeoPackage, FlatGeoBuf or GeoJSON
 works. To reproduce the demos, the underlying data is all public:
 
-- **Land cover (cos2023)** - Direção-Geral do Território (DGT), *Carta de Uso e Ocupação do Solo (COS),
-  Série 2, 2023*: metadata at [Carta de Ocupacão do Solo Conjuntural](https://snig.dgterritorio.gov.pt/rndg/srv/api/records/e9d25fc4-5a25-4c5e-9bce-d470f745d89e).
-- **Buildings (vida)** — VIDA *Combined Open Buildings* (Google Open Buildings + Microsoft Global ML
+- **Land cover (cos2023)**: Direção-Geral do Território (DGT), *Carta de Uso e Ocupação do Solo (COS),
+  Série 2, 2023*, metadata at [Carta de Ocupação do Solo Conjuntural](https://snig.dgterritorio.gov.pt/rndg/srv/api/records/e9d25fc4-5a25-4c5e-9bce-d470f745d89e).
+- **Buildings (vida)**: VIDA *Combined Open Buildings* (Google Open Buildings + Microsoft Global ML
   Buildings + OpenStreetMap), published as open data.
-- **NDVI (ndvi)** — Sentinel-2 imagery from the Copernicus Data Space:
+- **NDVI (ndvi)**: Sentinel-2 imagery from the Copernicus Data Space:
   [dataspace.copernicus.eu](https://dataspace.copernicus.eu).
 
-> **Note:** `cargo test` and `score.sh` expect a small set of sample rasters/vectors next to the crate
-> (the paths are in `tests/`). They aren't bundled — supply your own, or run the engine directly with
-> the CLI below against any dataset.
+> **Note:** `cargo test` and `score.sh` expect a small set of sample rasters and vectors next to the
+> crate (the paths are in `tests/`). They aren't bundled, so supply your own, or run the engine
+> directly with the CLI below against any dataset.
 
 ## Capabilities
 
-**Raster** : bespoke COG / BigTIFF reader (DEFLATE + LZW + horizontal/float predictor + YCbCr-JPEG +
+**Raster**: bespoke COG / BigTIFF reader (DEFLATE + LZW + horizontal/float predictor + YCbCr-JPEG +
 ZSTD + WEBP, overviews, mask/alpha, **8 dtypes lossless**), lazy/windowed open for huge files,
-warp/resample (nearest + bilinear), reprojection via libproj (incl. **polar UPS**), styling
-(RGB(A) passthrough + pseudocolor ramp), on-the-fly **band-math / NDVI**, **S3** cloud COGs,
+warp/resample (nearest and bilinear), reprojection via libproj (including **polar UPS**), styling
+(RGB(A) passthrough and pseudocolor ramp), on-the-fly **band-math / NDVI**, **S3** cloud COGs, and
 **multi-layer** YAML config.
 
-**Vector**:  GeoJSON, **native GeoPackage** and **FlatGeoBuf** readers (bespoke WKB decoder,
-`rusqlite` container, OGC R-tree **windowed reads**) → **tiny-skia** polygon / line / point
-rasterization, **SLD-first** styling (SLD 1.0 -> a Style IR) + a point-label engine, per-zoom LOD
-(shared-arc simplification), and offline **PMTiles** baking. Proven live on the Portuguese BUPi
-cadastre (**3.4 M parcels**) and the VIDA Iberia buildings (**14.9 M**).
+**Vector**: GeoJSON, **native GeoPackage** and **FlatGeoBuf** readers (bespoke WKB decoder,
+`rusqlite` container, OGC R-tree **windowed reads**), feeding **tiny-skia** polygon, line and point
+rasterization, **SLD-first** styling (SLD 1.0 lowered to a Style IR) with a point-label engine,
+per-zoom LOD (shared-arc simplification), and offline **PMTiles** baking. Proven live on the
+Portuguese BUPi cadastre (**3.4 M parcels**) and the VIDA Iberia buildings (**14.9 M**).
 
 **Protocols**: WMS 1.1.1 / 1.3.0 (GetMap · GetCapabilities · GetFeatureInfo · GetLegendGraphic, incl.
-EPSG:4326 axis flip + exceptions), **WMTS 1.0.0** (KVP + RESTful), **OSGeo TMS 1.0.0**, and **MVT
-vector tiles** (bespoke protobuf encoder + TileJSON), all over one engine. A raster viewer at
-`/viewer` and a cyan-on-black **"X-ray"** vector-tile inspector at `/xray`.
+EPSG:4326 axis flip and exceptions), **WMTS 1.0.0** (KVP and RESTful), **OSGeo TMS 1.0.0**, and **MVT
+vector tiles** (bespoke protobuf encoder and TileJSON), all over one engine. There is a raster viewer
+at `/viewer` and a cyan-on-black **"X-ray"** vector-tile inspector at `/xray`.
 
 ## CLI
 
@@ -114,16 +116,16 @@ terraserve serve --cog s2_stack.cog.tif --style fixtures/styles/ndvi.json --src-
 terraserve serve --config fixtures/layers.example.yaml --port 8080
 ```
 
-Full flag reference, the multi-layer YAML, and the **pitfalls** worth knowing before you deploy:
-**[terraserve.io/docs](https://terraserve.io/docs.html)**. How to style layers (raster ramps, SLD,
-MapLibre GL): **[terraserve.io/styling](https://terraserve.io/styling.html)**.
+Full flag reference, the multi-layer YAML, and the **pitfalls** worth knowing before you deploy are at
+**[terraserve.io/docs](https://terraserve.io/docs)**. How to style layers (raster ramps, SLD,
+MapLibre GL): **[terraserve.io/styling](https://terraserve.io/styling)**.
 
 ## The clean-room constraint
 
 `score.sh` enforces a **banned-crate gate** on every build: it forbids `gdal` and every off-the-shelf
 `tiff` / `geotiff` / `cog` / `flatgeobuf` **reader** crate. The COG container, IFD/tiling, windowed
 reads, warp/resample kernels, WKB/GeoPackage decoder, spatial-index traversal, style engine and OGC
-protocol layer are all bespoke. Only codec/infra crates (flate2 / zstd / weezl / zune-jpeg / png,
+protocol layer are all bespoke. Only codec and infra crates (flate2 / zstd / weezl / zune-jpeg / png,
 bundled `rusqlite`, tiny-skia) and the `proj` FFI (coordinate transforms only) are leaned on. The
 constraint can't drift, because CI fails the moment a banned crate appears.
 
@@ -132,10 +134,10 @@ constraint can't drift, because CI fails the moment a banned crate appears.
 | module / dir | role |
 |---|---|
 | `cog.rs` | bespoke TIFF/BigTIFF container + IFD/tile/overview parsing (dual-mode: resident or lazy/windowed) |
-| `decode.rs` | tile codecs — DEFLATE + LZW (+ predictors), YCbCr-JPEG / ZSTD / WEBP; 8 dtypes lossless |
-| `reproj.rs` | CRS transforms — a thin adapter over libproj (PROJ is not reimplemented) |
+| `decode.rs` | tile codecs: DEFLATE + LZW (+ predictors), YCbCr-JPEG / ZSTD / WEBP; 8 dtypes lossless |
+| `reproj.rs` | CRS transforms: a thin adapter over libproj (PROJ is not reimplemented) |
 | `render.rs` | pipeline: parse → grid via PROJ → overview → decode → warp/resample → style; `sample_point` (GFI) |
-| `backend.rs` | `RenderBackend` — batch-first, buffer-oriented (CPU impl; a wgpu backend is a later port) |
+| `backend.rs` | `RenderBackend`: batch-first, buffer-oriented (CPU impl; a wgpu backend is a later port) |
 | `style.rs`, `expr.rs` | RGB/pseudocolor styling; safe RPN band-math (NDVI), no code-exec |
 | `wms.rs` | WMS 1.1.1 / 1.3.0 GetMap / GetCapabilities / GetFeatureInfo / GetLegendGraphic |
 | `tms.rs`, `tms_http.rs`, `wmts.rs` | generic `TileMatrixSet` core (a tile IS a GetMap) + OSGeo TMS + WMTS |
@@ -150,17 +152,17 @@ constraint can't drift, because CI fails the moment a banned crate appears.
 - **Async-first, CPU work off the reactor.** The request/I/O path is async; `decode` / `warp` /
   `colorize` / `rasterize` are sync kernels dispatched via `spawn_blocking` / rayon so the reactor
   never stalls.
-- **I/O is the bottleneck, not the math.** Throughput is won in fetch scheduling + the tile cache, not
-  micro-optimized arithmetic.
+- **I/O is the bottleneck, not the math.** Throughput is won in fetch scheduling and the tile cache,
+  not micro-optimized arithmetic.
 - **GPU-capable, CPU-first.** `RenderBackend` stays batch-first so a `wgpu` backend is a port, not a rewrite.
-- **Correctness first** - validated against GDAL and PROJ as an *external* oracle (never linked):
+- **Correctness first**, validated against GDAL and PROJ as an *external* oracle (never linked):
   sub-pixel georegistration vs `gdalwarp`, exact point-values vs `gdallocationinfo`, plus OGC CITE.
 
 ## License
 
-**MPL-2.0**  see [LICENSE](LICENSE). File-level copyleft: TerraServe can be used in a larger work
+**MPL-2.0**, see [LICENSE](LICENSE). File-level copyleft: TerraServe can be used in a larger work
 under a license of your choice (including proprietary), but modifications to TerraServe's own source
-files stay under the MPL. This keeps the engine freely reusable — for example by the MIT-licensed
-[pygeoapi](https://pygeoapi.io) — while improvements to it come back to the project.
+files stay under the MPL. This keeps the engine freely reusable, for example by the MIT-licensed
+[pygeoapi](https://pygeoapi.io), while improvements to it come back to the project.
 
 © 2026 TerraOps. TerraServe™.


### PR DESCRIPTION
Publishes the friendlier README to main (currently only on develop).

- Rewrites the prose to read more like a person wrote it.
- Removes all 20 em-dashes (house style: commas / colons / parens).
- Points the docs & styling links at the extensionless routes (terraserve.io/docs, /styling) instead of the retired .html URLs.
- No claims changed; stats, CLI, capability tables and license are intact.

develop was also resynced to main (it had drifted 5 commits behind), so this PR is just the README commit.