### PR TITLE
chore(ci): move all actions to the Node 24 runtime

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -38,16 +38,16 @@ jobs:
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # GHCR requires a lowercase path; github.repository preserves the org's capital S.
       - name: Normalise image name
         id: img
         run: echo "name=${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -57,7 +57,7 @@ jobs:
       # neither architecture's build publishes a user-visible tag on its own.
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -72,7 +72,7 @@ jobs:
         env:
           digest: ${{ steps.build.outputs.digest }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: digest-${{ strategy.job-index }}
           path: /tmp/digests/*
@@ -90,15 +90,15 @@ jobs:
         id: img
         run: echo "name=${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: /tmp/digests
           pattern: digest-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -31,7 +31,7 @@ jobs:
             runner: ubuntu-24.04-arm      # free arm64 runner on public repos
             target: aarch64-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build wheel (manylinux_2_28, PROJ vendored)
         uses: PyO3/maturin-action@v1
@@ -51,7 +51,7 @@ jobs:
           LIBCLANG_PATH: /usr/lib64
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.arch }}
           path: bindings/python/dist/*.whl
@@ -64,12 +64,12 @@ jobs:
     permissions:
       contents: write     # create the release and upload assets
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true
       - name: Attach wheels to the GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*.whl
           generate_release_notes: true


### PR DESCRIPTION
Bumps the GitHub Actions used by the publish workflows off the deprecated Node 20 runtime.

Was pushed on 2026-07-27 but never had a PR opened, so it has been sitting unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fsn3PzqiBJEEcQ6Z9HhvM