### PR TITLE
fix(mvt): advertise the configured public URL, not a guessed http:// origin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ FROM debian:trixie-slim AS runtime
 # — it just appears as an orphan under the org.
 LABEL org.opencontainers.image.source="https://github.com/terraops-org/TerraServe" \
       org.opencontainers.image.description="Clean-room raster + vector map tile server in Rust — WMS/WMTS/TMS/MVT, no GDAL." \
-      org.opencontainers.image.licenses="AGPL-3.0-or-later" \
+      org.opencontainers.image.licenses="MPL-2.0" \
       org.opencontainers.image.title="TerraServe"
 
 # Runtime deps:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -717,6 +717,10 @@ pub fn run_serve(args: &ServeArgs) -> Result<(), Error> {
     };
     println!("admission control: max {max_inflight} concurrent renders (excess requests queue)");
     let mut state = server::ServeState::new(layers, base_url, max_inflight);
+    // Kept separate from `base_url` (which falls back to the bind address) so the MVT
+    // TileJSON/style.json origin can tell "operator declared the public URL" from "we guessed",
+    // and prefer the declared one over the request's Host header. See `ServeState.public_url`.
+    state.public_url = args.public_url.clone();
     state.pmtiles_flush_interval = args.pmtiles_flush_interval;
     state.mvt_max_features = args.mvt_max_features;
     state.mvt_min_feature_px = args.mvt_min_feature_px;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod tms_http;
 pub mod vector;
 pub mod wms;
 pub mod wmts;
+pub mod xml;
 
 use clap::Args;
 use std::io::Write;
@@ -1302,6 +1303,17 @@ fn build_vector_layer(
     // build below: a typo'd style or font path used to only error out after loading the gpkg and
     // building topology, wasting real wall-clock time on a real build (~2.7 min on a COS-sized
     // coverage) for a mistake that's knowable in milliseconds.
+    // Reject an unknown source SCHEME before anything else. Without this an unrecognised
+    // scheme falls through the format branches to the GeoPackage opener, which then fails deep
+    // inside SQLite complaining about a file that was never a file -- an error naming the wrong
+    // format entirely. `postgis://` lands here today; supporting it means adding a branch, not
+    // another extension test.
+    if let vector::uri::SourceKind::Unsupported(scheme) = vector::uri::classify(geojson_path) {
+        return Err(format!(
+            "layer '{name}': unsupported vector source scheme `{scheme}://` in {geojson_path}.              Supported: a local path or `s3://` pointing at .fgb, .gpkg or .geojson."
+        )
+        .into());
+    }
     let style =
         vector::style::Style::parse(vec_style_path, &read_config_string(vec_style_path, s3)?)?;
     let font = read_config_bytes(font_path, s3).map_err(|e| format!("font {e}"))?;
@@ -1313,7 +1325,10 @@ fn build_vector_layer(
     // `config::LayerConfig` gains no new field. Opens via `s3::AnySource` (local or `s3://`) —
     // every byte already flows through `RangeSource`, so this reader was S3-capable by
     // construction; the local-only restriction was just the opener.
-    if geojson_path.ends_with(".fgb") {
+    if matches!(
+        vector::uri::classify(geojson_path),
+        vector::uri::SourceKind::FlatGeoBuf
+    ) {
         if args.topology_simplify.is_some()
             || args.topology_dissolve.is_some()
             || args.keep_fields.is_some()
@@ -1420,8 +1435,10 @@ fn build_vector_layer(
     // early-return only fires when none of them are requested AND the file actually has a usable
     // rtree (`gpkg_has_rtree` — a cheap sqlite_master probe, no feature read); otherwise this
     // falls through, UNCHANGED, to the load-all `.gpkg` arm below.
-    let windowed_gpkg = geojson_path.ends_with(".gpkg")
-        && args.topology_simplify.is_none()
+    let windowed_gpkg = matches!(
+        vector::uri::classify(geojson_path),
+        vector::uri::SourceKind::GeoPackage
+    ) && args.topology_simplify.is_none()
         && args.topology_dissolve.is_none()
         && args.keep_fields.is_none()
         && vector::gpkg::gpkg_has_rtree(geojson_path, None);
@@ -1491,9 +1508,10 @@ fn build_vector_layer(
         });
     }
 
-    let (src, src_crs): (std::sync::Arc<dyn FeatureSource>, String) = if geojson_path
-        .ends_with(".gpkg")
-    {
+    let (src, src_crs): (std::sync::Arc<dyn FeatureSource>, String) = if matches!(
+        vector::uri::classify(geojson_path),
+        vector::uri::SourceKind::GeoPackage
+    ) {
         let g = vector::gpkg::GpkgSource::load(geojson_path, None)?;
         let crs = if args.src_crs.is_none() {
             match g.crs() {
@@ -1801,7 +1819,14 @@ fn load_topology_source(
     path: &str,
     layer: Option<&str>,
 ) -> Result<vector::source::VectorSource, Error> {
-    if path.ends_with(".fgb") {
+    let kind = vector::uri::classify(path);
+    if let vector::uri::SourceKind::Unsupported(scheme) = &kind {
+        return Err(format!(
+            "unsupported vector source scheme `{scheme}://` in {path}.              Supported: a local path or `s3://` pointing at .fgb, .gpkg or .geojson."
+        )
+        .into());
+    }
+    if kind == vector::uri::SourceKind::FlatGeoBuf {
         if layer.is_some() {
             eprintln!(
                 "warning: --layer is ignored for a FlatGeoBuf source ({path}); it has a single layer"
@@ -1817,7 +1842,7 @@ fn load_topology_source(
             fgb,
         )));
     }
-    if path.ends_with(".geojson") || path.ends_with(".json") {
+    if kind == vector::uri::SourceKind::GeoJson {
         if layer.is_some() {
             eprintln!("warning: --layer is ignored for a GeoJSON source ({path})");
         }
@@ -1867,6 +1892,25 @@ pub fn run_build_topology(args: &BuildTopologyArgs) -> Result<(), Error> {
 
 #[cfg(test)]
 mod build_topology_cli_tests {
+    /// An unknown SCHEME must be rejected by name, up front. Before the URI registry it fell
+    /// through every extension test to the GeoPackage opener and failed inside SQLite,
+    /// reporting a file problem for something that was never a file. This is also the seam a
+    /// PostGIS reader attaches to, so the message must name what IS supported.
+    #[test]
+    fn unsupported_scheme_is_rejected_by_name() {
+        // `match`, not `expect_err`: the Ok type (`VectorSource`) is not `Debug`, by design -
+        // it holds trait objects.
+        let msg = match super::load_topology_source("postgis://user@host/db?table=roads", None) {
+            Ok(_) => panic!("an unknown scheme must not reach a file opener"),
+            Err(e) => e.to_string(),
+        };
+        assert!(msg.contains("postgis://"), "must name the scheme: {msg}");
+        assert!(
+            msg.contains(".fgb") && msg.contains(".gpkg"),
+            "must say what IS supported: {msg}"
+        );
+    }
+
     use super::*;
     use crate::vector::topology::BuildReport;
 

--- a/src/mvt_http.rs
+++ b/src/mvt_http.rs
@@ -218,47 +218,14 @@ pub fn pmtiles_metadata_json(layer: &Layer, grid_id: Option<&str>) -> String {
 /// `Host` header (the address the client actually reached us on) so URLs are reachable even when the
 /// server binds `0.0.0.0` (whose literal address is not routable from another machine). Falls back
 /// to the configured `base_url` (e.g. an explicit `--public-url`) when there's no Host header.
+/// Thin delegate to the single shared derivation, `ServeState::advertised_origin`. Kept as a
+/// named function because this module's call sites and its regression tests read through it.
 fn advertised_origin(
     state: &ServeState,
     request_host: Option<&str>,
     forwarded_proto: Option<&str>,
 ) -> String {
-    // An explicitly configured `--public-url` is AUTHORITATIVE, and must outrank the Host header.
-    // It is the only source carrying both the public scheme and the path prefix that a reverse
-    // proxy mounts us under (`https://terraserve.io/demo/vida/wms`); a Host header carries
-    // neither. Preferring the header is what shipped `http://terraserve.io/mvt/vida/...` to
-    // production: wrong scheme (mixed-content blocked) AND no `/demo/vida` prefix (404).
-    // `deploy/vps/docker-compose.yml` already documents `--public-url` as load-bearing for the
-    // raster viewer, which reads it through `tms_http::tms_root`; this makes the MVT path agree.
-    if let Some(pu) = state.public_url.as_deref() {
-        return trim_origin(pu);
-    }
-    // No `--public-url`: derive from the request, since `base_url` is then only the BIND address
-    // (`http://127.0.0.1:8080/wms`) and useless to an external client. Take the scheme from
-    // `X-Forwarded-Proto` — Traefik terminates TLS, so the connection we see is always plain HTTP
-    // and the scheme cannot be inferred from it. A proxy chain sends a comma-separated list whose
-    // FIRST entry is the original client-facing scheme.
-    match request_host {
-        Some(h) if !h.is_empty() => {
-            let scheme = forwarded_proto
-                .and_then(|p| p.split(',').next())
-                .map(str::trim)
-                .filter(|p| !p.is_empty())
-                .unwrap_or("http");
-            format!("{scheme}://{h}")
-        }
-        _ => trim_origin(&state.base_url),
-    }
-}
-
-/// A configured URL reduced to the origin the tile paths hang off: drop the conventional `/wms`
-/// endpoint suffix and any trailing slash, so composing `{origin}/mvt/...` never doubles a
-/// separator. A URL without the `/wms` suffix is left alone apart from the trailing slash.
-fn trim_origin(url: &str) -> String {
-    url.strip_suffix("/wms")
-        .unwrap_or(url)
-        .trim_end_matches('/')
-        .to_string()
+    state.advertised_origin(request_host, forwarded_proto)
 }
 
 /// A **MapLibre/Mapbox GL Style JSON** (`version: 8`) for `{layer}` — the "one URL" a client

--- a/src/mvt_http.rs
+++ b/src/mvt_http.rs
@@ -164,12 +164,13 @@ pub fn tilejson_doc(
     layer: &str,
     tms_id: &str,
     request_host: Option<&str>,
+    forwarded_proto: Option<&str>,
 ) -> Result<String, (u16, String)> {
     let (l, v) = resolve_vector(state, layer)?;
     let grid = resolve_grid(l, tms_id)?;
     let minzoom = grid.levels.iter().map(|lv| lv.z).min().unwrap_or(0);
     let maxzoom = grid.levels.iter().map(|lv| lv.z).max().unwrap_or(0);
-    let origin = advertised_origin(state, request_host);
+    let origin = advertised_origin(state, request_host, forwarded_proto);
     let tile_url = format!("{origin}/mvt/{layer}/{tms_id}/{{z}}/{{x}}/{{y}}.pbf");
 
     // Attribute schema is precomputed once at layer load (see `feature_field_schema`); reading it
@@ -217,16 +218,47 @@ pub fn pmtiles_metadata_json(layer: &Layer, grid_id: Option<&str>) -> String {
 /// `Host` header (the address the client actually reached us on) so URLs are reachable even when the
 /// server binds `0.0.0.0` (whose literal address is not routable from another machine). Falls back
 /// to the configured `base_url` (e.g. an explicit `--public-url`) when there's no Host header.
-fn advertised_origin(state: &ServeState, request_host: Option<&str>) -> String {
-    match request_host {
-        Some(h) if !h.is_empty() => format!("http://{h}"),
-        _ => state
-            .base_url
-            .strip_suffix("/wms")
-            .unwrap_or(&state.base_url)
-            .trim_end_matches('/')
-            .to_string(),
+fn advertised_origin(
+    state: &ServeState,
+    request_host: Option<&str>,
+    forwarded_proto: Option<&str>,
+) -> String {
+    // An explicitly configured `--public-url` is AUTHORITATIVE, and must outrank the Host header.
+    // It is the only source carrying both the public scheme and the path prefix that a reverse
+    // proxy mounts us under (`https://terraserve.io/demo/vida/wms`); a Host header carries
+    // neither. Preferring the header is what shipped `http://terraserve.io/mvt/vida/...` to
+    // production: wrong scheme (mixed-content blocked) AND no `/demo/vida` prefix (404).
+    // `deploy/vps/docker-compose.yml` already documents `--public-url` as load-bearing for the
+    // raster viewer, which reads it through `tms_http::tms_root`; this makes the MVT path agree.
+    if let Some(pu) = state.public_url.as_deref() {
+        return trim_origin(pu);
     }
+    // No `--public-url`: derive from the request, since `base_url` is then only the BIND address
+    // (`http://127.0.0.1:8080/wms`) and useless to an external client. Take the scheme from
+    // `X-Forwarded-Proto` — Traefik terminates TLS, so the connection we see is always plain HTTP
+    // and the scheme cannot be inferred from it. A proxy chain sends a comma-separated list whose
+    // FIRST entry is the original client-facing scheme.
+    match request_host {
+        Some(h) if !h.is_empty() => {
+            let scheme = forwarded_proto
+                .and_then(|p| p.split(',').next())
+                .map(str::trim)
+                .filter(|p| !p.is_empty())
+                .unwrap_or("http");
+            format!("{scheme}://{h}")
+        }
+        _ => trim_origin(&state.base_url),
+    }
+}
+
+/// A configured URL reduced to the origin the tile paths hang off: drop the conventional `/wms`
+/// endpoint suffix and any trailing slash, so composing `{origin}/mvt/...` never doubles a
+/// separator. A URL without the `/wms` suffix is left alone apart from the trailing slash.
+fn trim_origin(url: &str) -> String {
+    url.strip_suffix("/wms")
+        .unwrap_or(url)
+        .trim_end_matches('/')
+        .to_string()
 }
 
 /// A **MapLibre/Mapbox GL Style JSON** (`version: 8`) for `{layer}` — the "one URL" a client
@@ -315,10 +347,11 @@ pub fn style_json(
     layer: &str,
     grid_id: &str,
     request_host: Option<&str>,
+    forwarded_proto: Option<&str>,
 ) -> Result<String, (u16, String)> {
     // Validate: the layer must exist and be a vector layer (MVT/style only applies to vectors).
     let (_, v) = resolve_vector(state, layer)?;
-    let origin = advertised_origin(state, request_host);
+    let origin = advertised_origin(state, request_host, forwarded_proto);
     let source_url = format!("{origin}/mvt/{layer}/{grid_id}.json");
 
     // An operator-supplied `--mvt-style` (a JSON object `{ "layers": [...], "metadata": {...} }`,
@@ -1045,5 +1078,93 @@ mod tests {
         assert_ne!(got_a, got_b);
 
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    // ---- advertised origin (TileJSON / style.json `sources.*.url`) ----------------------------
+    //
+    // Regression tests for a LIVE production bug, reproduced 2026-08-02 against terraserve.io:
+    //
+    //   GET https://terraserve.io/demo/vida/mvt/vida/style.json
+    //     -> "url": "http://terraserve.io/mvt/vida/WebMercatorQuad.json"   (404, and mixed-content
+    //                                                                       blocked before that)
+    //   correct:  https://terraserve.io/demo/vida/mvt/vida/WebMercatorQuad.json   (200)
+    //
+    // `advertised_origin` preferred the Host header unconditionally, which (a) hardcoded the
+    // `http://` scheme even behind TLS-terminating Traefik and (b) rebuilt the origin from the
+    // host alone, discarding the `/demo/vida` path prefix. Because HTTP/1.1 always sends `Host`,
+    // the configured `--public-url` branch was effectively dead code.
+
+    fn state_with(public_url: Option<&str>, base_url: &str) -> crate::server::ServeState {
+        let mut st = crate::server::ServeState::new(vec![], base_url.into(), 1);
+        st.public_url = public_url.map(|s| s.to_string());
+        st
+    }
+
+    /// The bug itself: an explicitly configured `--public-url` is authoritative. It is the only
+    /// source that carries BOTH the public scheme and the path prefix, neither of which any
+    /// request header reliably provides, so it must win over the Host header.
+    #[test]
+    fn advertised_origin_prefers_explicit_public_url_over_host_header() {
+        let st = state_with(
+            Some("https://terraserve.io/demo/vida/wms"),
+            "https://terraserve.io/demo/vida/wms",
+        );
+        let got = super::advertised_origin(&st, Some("terraserve.io"), None);
+        assert_eq!(
+            got, "https://terraserve.io/demo/vida",
+            "configured --public-url must win over the Host header (scheme AND path prefix)"
+        );
+    }
+
+    /// Traefik terminates TLS, so the origin scheme must come from `X-Forwarded-Proto`, never be
+    /// assumed. Applies when there is no `--public-url` to be authoritative.
+    #[test]
+    fn advertised_origin_honours_forwarded_proto_when_no_public_url() {
+        let st = state_with(None, "http://127.0.0.1:8080/wms");
+        let got = super::advertised_origin(&st, Some("example.org"), Some("https"));
+        assert_eq!(got, "https://example.org");
+    }
+
+    /// A proxy may send a comma-separated `X-Forwarded-Proto` chain; the FIRST entry is the
+    /// original client-facing scheme.
+    #[test]
+    fn advertised_origin_takes_first_forwarded_proto_of_a_chain() {
+        let st = state_with(None, "http://127.0.0.1:8080/wms");
+        let got = super::advertised_origin(&st, Some("example.org"), Some("https, http"));
+        assert_eq!(got, "https://example.org");
+    }
+
+    /// Unchanged behaviour for a plain local run: no `--public-url`, no proxy headers -> derive
+    /// from the Host header over http. This is what keeps `serve` working with no configuration.
+    #[test]
+    fn advertised_origin_falls_back_to_http_host_without_public_url_or_proto() {
+        let st = state_with(None, "http://127.0.0.1:8080/wms");
+        let got = super::advertised_origin(&st, Some("localhost:8080"), None);
+        assert_eq!(got, "http://localhost:8080");
+    }
+
+    /// With neither a `--public-url` nor a Host header, fall back to the bind-address base_url,
+    /// with the `/wms` suffix trimmed (the origin is the mount point, not the WMS endpoint).
+    #[test]
+    fn advertised_origin_falls_back_to_base_url_without_host() {
+        let st = state_with(None, "http://127.0.0.1:8080/wms");
+        let got = super::advertised_origin(&st, None, None);
+        assert_eq!(got, "http://127.0.0.1:8080");
+    }
+
+    /// A `--public-url` given WITHOUT the conventional `/wms` suffix must not be mangled, and a
+    /// trailing slash must not produce a doubled separator in the composed tile URL.
+    #[test]
+    fn advertised_origin_normalises_public_url_without_wms_suffix_or_trailing_slash() {
+        let a = state_with(Some("https://maps.example.org/ts/"), "unused");
+        assert_eq!(
+            super::advertised_origin(&a, Some("maps.example.org"), None),
+            "https://maps.example.org/ts"
+        );
+        let b = state_with(Some("https://maps.example.org/ts"), "unused");
+        assert_eq!(
+            super::advertised_origin(&b, Some("maps.example.org"), None),
+            "https://maps.example.org/ts"
+        );
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -219,6 +219,49 @@ pub struct ServeState {
 }
 
 impl ServeState {
+    /// The origin every advertised URL hangs off: `https://host[/prefix]`, with no trailing
+    /// slash and no `/wms` suffix.
+    ///
+    /// This is THE single derivation. It used to exist four times, once per front-end
+    /// (`wms::online_resource`, `wmts::bases`, `tms_http::tms_root`, `mvt_http`), and the four
+    /// copies had drifted: only the MVT one learned about `X-Forwarded-Proto`, so TMS and WMTS
+    /// could not construct an `https` URL from a request at all and depended entirely on
+    /// `--public-url` being set. One of the copies also hardcoded `http://`, which shipped
+    /// broken tile URLs to production.
+    ///
+    /// Precedence, and why:
+    ///
+    /// 1. An explicitly configured `--public-url` WINS. It is the only source carrying both
+    ///    the public scheme and the reverse-proxy path prefix; no request header carries the
+    ///    prefix at all.
+    /// 2. Otherwise derive from the request, because `base_url` has then fallen back to the
+    ///    BIND address (`http://127.0.0.1:8080/wms`), which is useless to an external client.
+    ///    The scheme comes from `X-Forwarded-Proto`: a TLS-terminating proxy means the
+    ///    connection this process sees is always plain HTTP, so the scheme cannot be inferred
+    ///    from it. A proxy chain sends a comma-separated list whose FIRST entry is the
+    ///    original client-facing scheme.
+    /// 3. With no Host header either, fall back to `base_url`.
+    pub fn advertised_origin(
+        &self,
+        request_host: Option<&str>,
+        forwarded_proto: Option<&str>,
+    ) -> String {
+        if let Some(pu) = self.public_url.as_deref() {
+            return trim_origin(pu);
+        }
+        match request_host {
+            Some(h) if !h.is_empty() => {
+                let scheme = forwarded_proto
+                    .and_then(|p| p.split(',').next())
+                    .map(str::trim)
+                    .filter(|p| !p.is_empty())
+                    .unwrap_or("http");
+                format!("{scheme}://{h}")
+            }
+            _ => trim_origin(&self.base_url),
+        }
+    }
+
     /// Build the service state with an admission-control limiter of `max_inflight` permits (min 1).
     /// `mvt_max_features` starts at the default; callers that expose the flag set it afterwards.
     pub fn new(layers: Vec<Layer>, base_url: String, max_inflight: usize) -> ServeState {
@@ -544,17 +587,21 @@ fn status_response(status: u16, msg: String) -> Response {
 }
 
 /// `GET /tms/1.0.0/` — the TileMapService document (all layer×grid TileMaps).
-async fn tms_service_handler(State(state): State<Arc<ServeState>>) -> Response {
-    let root = crate::tms_http::tms_root(&state.base_url);
+async fn tms_service_handler(
+    State(state): State<Arc<ServeState>>,
+    headers: axum::http::HeaderMap,
+) -> Response {
+    let root = crate::tms_http::tms_root(&origin_of(&state, &headers));
     xml_response(crate::tms_http::tilemapservice_xml(&state, &root))
 }
 
 /// `GET /tms/1.0.0/{layer}[@{grid}]` — a TileMap document.
 async fn tms_tilemap_handler(
     State(state): State<Arc<ServeState>>,
+    headers: axum::http::HeaderMap,
     Path(layerspec): Path<String>,
 ) -> Response {
-    let root = crate::tms_http::tms_root(&state.base_url);
+    let root = crate::tms_http::tms_root(&origin_of(&state, &headers));
     match crate::tms_http::tilemap_doc(&state, &layerspec, &root) {
         Ok(xml) => xml_response(xml),
         Err((status, msg)) => status_response(status, msg),
@@ -674,6 +721,25 @@ async fn mvt_flush_handler(
     }
 }
 
+/// A configured URL reduced to the origin that advertised paths hang off: drop the
+/// conventional `/wms` endpoint suffix and any trailing slash, so composing `{origin}/mvt/...`
+/// or `{origin}/tms/1.0.0` never doubles a separator. A URL without the `/wms` suffix is left
+/// alone apart from the trailing slash.
+fn trim_origin(url: &str) -> String {
+    url.strip_suffix("/wms")
+        .unwrap_or(url)
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// The advertised origin for THIS request: pulls `Host` and `X-Forwarded-Proto` off the
+/// header map and hands them to the single shared derivation. Every front-end that emits an
+/// absolute URL goes through here, so a proxied deployment gets one consistent answer.
+fn origin_of(state: &ServeState, headers: &axum::http::HeaderMap) -> String {
+    let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
+    state.advertised_origin(host, forwarded_proto(headers))
+}
+
 /// The client-facing scheme, as reported by the reverse proxy's `X-Forwarded-Proto`.
 ///
 /// Traefik terminates TLS in front of us (see `deploy/vps/`), so the connection this process
@@ -760,9 +826,13 @@ fn wmts_exception_response(e: crate::wmts::WmtsErr) -> Response {
 }
 
 /// `GET /wmts?…` — WMTS KVP binding (GetCapabilities / GetTile / OWS exception).
-async fn wmts_kvp_handler(State(state): State<Arc<ServeState>>, RawQuery(q): RawQuery) -> Response {
+async fn wmts_kvp_handler(
+    State(state): State<Arc<ServeState>>,
+    headers: axum::http::HeaderMap,
+    RawQuery(q): RawQuery,
+) -> Response {
     let query = q.unwrap_or_default();
-    let (kvp_base, rest_base) = crate::wmts::bases(&state.base_url);
+    let (kvp_base, rest_base) = crate::wmts::bases(&origin_of(&state, &headers));
     match crate::wmts::parse_kvp(&query) {
         crate::wmts::WmtsRequest::GetCapabilities => {
             xml_response(crate::wmts::capabilities_xml(&state, &kvp_base, &rest_base))
@@ -855,8 +925,11 @@ async fn wmts_kvp_handler(State(state): State<Arc<ServeState>>, RawQuery(q): Raw
 }
 
 /// `GET /wmts/1.0.0/WMTSCapabilities.xml` — WMTS RESTful GetCapabilities.
-async fn wmts_caps_handler(State(state): State<Arc<ServeState>>) -> Response {
-    let (kvp_base, rest_base) = crate::wmts::bases(&state.base_url);
+async fn wmts_caps_handler(
+    State(state): State<Arc<ServeState>>,
+    headers: axum::http::HeaderMap,
+) -> Response {
+    let (kvp_base, rest_base) = crate::wmts::bases(&origin_of(&state, &headers));
     xml_response(crate::wmts::capabilities_xml(&state, &kvp_base, &rest_base))
 }
 
@@ -885,8 +958,11 @@ async fn wmts_rest_tile_handler(
 }
 
 /// `GET /viewer` — the built-in map viewer (filled in Task 6).
-async fn viewer_handler(State(state): State<Arc<ServeState>>) -> Response {
-    let html = crate::tms_http::viewer_html(&state);
+async fn viewer_handler(
+    State(state): State<Arc<ServeState>>,
+    headers: axum::http::HeaderMap,
+) -> Response {
+    let html = crate::tms_http::viewer_html(&state, &origin_of(&state, &headers));
     Response::builder()
         .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
         .body(Body::from(html))
@@ -974,6 +1050,71 @@ async fn xray_handler(State(state): State<Arc<ServeState>>) -> Response {
 /// the call site) so it's directly unit-testable without spinning an HTTP server.
 pub fn xray_html() -> &'static str {
     include_str!("xray.html")
+}
+
+#[cfg(test)]
+mod advertised_origin_tests {
+    use super::ServeState;
+
+    fn state_with(public_url: Option<&str>, base_url: &str) -> ServeState {
+        let mut st = ServeState::new(vec![], base_url.into(), 1);
+        st.public_url = public_url.map(str::to_string);
+        st
+    }
+
+    /// The TMS and WMTS front-ends derive their advertised roots from this. Before the
+    /// extraction each of them had its OWN copy of the origin logic taking only `base_url`,
+    /// so neither could see `X-Forwarded-Proto` and neither could emit an `https` URL from
+    /// the request. Only the MVT copy had been fixed; this is the shared one they now use.
+    #[test]
+    fn honours_forwarded_proto_so_tms_and_wmts_can_emit_https() {
+        let st = state_with(None, "http://127.0.0.1:8080/wms");
+        assert_eq!(
+            st.advertised_origin(Some("example.org"), Some("https")),
+            "https://example.org"
+        );
+    }
+
+    #[test]
+    fn explicit_public_url_outranks_the_host_header() {
+        let st = state_with(
+            Some("https://terraserve.io/demo/vida/wms"),
+            "http://127.0.0.1:8080/wms",
+        );
+        assert_eq!(
+            st.advertised_origin(Some("terraserve.io"), None),
+            "https://terraserve.io/demo/vida"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_http_host_then_to_base_url() {
+        let st = state_with(None, "http://127.0.0.1:8080/wms");
+        assert_eq!(
+            st.advertised_origin(Some("localhost:8080"), None),
+            "http://localhost:8080"
+        );
+        assert_eq!(st.advertised_origin(None, None), "http://127.0.0.1:8080");
+    }
+
+    /// The TMS/WMTS path builders now only append to an already-derived origin, so a
+    /// proxied deployment gets the right scheme and prefix in its advertised roots.
+    #[test]
+    fn tms_and_wmts_roots_compose_on_the_shared_origin() {
+        let st = state_with(Some("https://terraserve.io/demo/swiss/wms"), "unused");
+        let origin = st.advertised_origin(Some("terraserve.io"), Some("https"));
+        assert_eq!(
+            crate::tms_http::tms_root(&origin),
+            "https://terraserve.io/demo/swiss/tms/1.0.0"
+        );
+        assert_eq!(
+            crate::wmts::bases(&origin),
+            (
+                "https://terraserve.io/demo/swiss/wmts".to_string(),
+                "https://terraserve.io/demo/swiss/wmts/1.0.0".to_string()
+            )
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -155,6 +155,12 @@ pub struct ServeState {
     pub layers: Vec<Layer>,
     /// Advertised OnlineResource / GetMap endpoint (injected into GetCapabilities).
     pub base_url: String,
+    /// The operator's `--public-url`, kept SEPARATE from `base_url` so we can tell "the operator
+    /// declared the public URL" from "we defaulted to the bind address". `base_url` collapses the
+    /// two (it falls back to `http://{host}:{port}/wms`), and that ambiguity is what let
+    /// `mvt_http::advertised_origin` ignore a configured `--public-url` in favour of the Host
+    /// header, advertising `http://` tile URLs with the path prefix stripped. `None` = not set.
+    pub public_url: Option<String>,
     /// **Admission control:** caps the number of CONCURRENT renders. A request acquires a permit
     /// before its `spawn_blocking` render and holds it until the response is built, so peak memory =
     /// (permits × per-request render buffers) + the bounded caches — hard-bounded regardless of how
@@ -219,6 +225,7 @@ impl ServeState {
         ServeState {
             layers,
             base_url,
+            public_url: None,
             render_limiter: Arc::new(tokio::sync::Semaphore::new(max_inflight.max(1))),
             mvt_max_features: crate::vector::mvt::DEFAULT_MAX_FEATURES_PER_TILE,
             mvt_min_feature_px: 0.0,
@@ -667,6 +674,18 @@ async fn mvt_flush_handler(
     }
 }
 
+/// The client-facing scheme, as reported by the reverse proxy's `X-Forwarded-Proto`.
+///
+/// Traefik terminates TLS in front of us (see `deploy/vps/`), so the connection this process
+/// accepts is ALWAYS plain HTTP and the public scheme cannot be inferred from it. Without this
+/// header an HTTPS deployment advertises `http://` URLs, which browsers block as mixed content.
+/// `None` when absent (direct/local run) — callers fall back to `http`.
+fn forwarded_proto(headers: &axum::http::HeaderMap) -> Option<&str> {
+    headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+}
+
 /// `GET /mvt/{layer}/{tms}.json` — a TileJSON 3.0.0 document for the layer×grid.
 async fn mvt_tilejson_handler(
     State(state): State<Arc<ServeState>>,
@@ -675,7 +694,8 @@ async fn mvt_tilejson_handler(
 ) -> Response {
     let tms = tmsjson.strip_suffix(".json").unwrap_or(&tmsjson);
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
-    match crate::mvt_http::tilejson_doc(&state, &layer, tms, host) {
+    let proto = forwarded_proto(&headers);
+    match crate::mvt_http::tilejson_doc(&state, &layer, tms, host, proto) {
         Ok(json) => Response::builder()
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(json))
@@ -698,12 +718,13 @@ async fn mvt_style_handler(
     Path(layer): Path<String>,
 ) -> Response {
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
+    let proto = forwarded_proto(&headers);
     let grid_id = q
         .as_deref()
         .and_then(|qs| qs.split('&').find_map(|kv| kv.strip_prefix("tms=")))
         .map(crate::wms::percent_decode)
         .unwrap_or_else(|| "WebMercatorQuad".to_string());
-    match crate::mvt_http::style_json(&state, &layer, &grid_id, host) {
+    match crate::mvt_http::style_json(&state, &layer, &grid_id, host, proto) {
         Ok(json) => Response::builder()
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(json))

--- a/src/tms.rs
+++ b/src/tms.rs
@@ -528,7 +528,7 @@ mod tests {
         assert_eq!(tms.levels.len(), 2);
         assert_eq!(tms.levels[0].z, 0);
         assert!((tms.levels[0].resolution - 4000.0).abs() < 1e-6); // cellSize path
-        // scaleDenominator 7142857.14 * 0.00028 / meters_per_unit(EPSG:2056=1.0) = 2000.0
+                                                                   // scaleDenominator 7142857.14 * 0.00028 / meters_per_unit(EPSG:2056=1.0) = 2000.0
         assert!((tms.levels[1].resolution - 2000.0).abs() < 1e-3);
         assert_eq!(tms.origin_x, 2420000.0);
         assert_eq!(tms.origin_y, 1350000.0);

--- a/src/tms_http.rs
+++ b/src/tms_http.rs
@@ -13,12 +13,12 @@
 use crate::server::{Layer, PublishedGrid, ServeState};
 use crate::tms::{strip_size_suffix, TileFactory, TileMatrixSet, TileRequest};
 
-/// The TMS root URL, derived from the advertised WMS base (`…/wms` → `…/tms/1.0.0`).
-pub fn tms_root(base_url: &str) -> String {
-    let origin = base_url
-        .strip_suffix("/wms")
-        .unwrap_or(base_url)
-        .trim_end_matches('/');
+/// The TMS service root, composed on an ALREADY-DERIVED origin.
+///
+/// This used to take `base_url` and derive the origin itself, which is why TMS could not
+/// honour `X-Forwarded-Proto`: it never saw the request. Derivation now lives in exactly one
+/// place, `ServeState::advertised_origin`, and this only appends the path.
+pub fn tms_root(origin: &str) -> String {
     format!("{origin}/tms/1.0.0")
 }
 
@@ -308,15 +308,19 @@ var map = new ol.Map({{
     )
 }
 
-pub fn viewer_html(state: &ServeState) -> String {
-    let root = tms_root(&state.base_url);
+/// `origin` is the request's advertised origin (`ServeState::advertised_origin`), NOT
+/// `state.base_url`. The viewer templates ABSOLUTE tile and WMS URLs into its HTML, so behind a
+/// reverse proxy those must carry the public scheme and path prefix or every request the page
+/// makes lands on the origin root and 404s.
+pub fn viewer_html(state: &ServeState, origin: &str) -> String {
+    let root = tms_root(origin);
     let Some(layer) = state.layers.first() else {
         return "<!doctype html><meta charset=utf-8><title>TerraServe</title><p>No layers published.".to_string();
     };
     // A vector (label) layer has no tile grids — serve it as a single WMS GetMap image
     // (OpenLayers ImageWMS) over an OSM basemap so the labels are visible.
     if layer.vector.is_some() {
-        return vector_viewer_html(&state.base_url, layer);
+        return vector_viewer_html(&format!("{origin}/wms"), layer);
     }
     let Some(pg) = layer.grids.first() else {
         return format!(

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -27,4 +27,5 @@ pub mod sld_lower;
 pub mod source;
 pub mod style;
 pub mod topology;
+pub mod uri;
 pub mod wkb;

--- a/src/vector/uri.rs
+++ b/src/vector/uri.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2026 TerraOps <https://terraops.org>
+
+//! One place that decides what a vector source spec IS.
+//!
+//! The format decision used to be five `path.ends_with(".fgb")`-style string tests scattered
+//! across two functions in `lib.rs`. That worked while every source was a file, and stops
+//! working the moment one is not: a database source has no extension to sniff, so there is
+//! nowhere for `postgis://…` to dispatch.
+//!
+//! ## Transport scheme vs format scheme
+//!
+//! The distinction that makes this work, and the reason a naive "match on the URI scheme"
+//! registry would be wrong:
+//!
+//! - `s3://bucket/roads.fgb` — `s3` is a **transport**. It says where the bytes live, not what
+//!   they are. The format is still FlatGeoBuf, and the reader is the same one a local `.fgb`
+//!   uses, because every byte already flows through `RangeSource`.
+//! - `postgis://host/db?table=roads` — `postgis` is a **format**. There is no file, no
+//!   extension, and the reader is completely different.
+//!
+//! So: strip a known transport scheme, then classify what remains. An unknown scheme is
+//! treated as a format, which is exactly the seam a new source type needs.
+
+/// What kind of reader a vector source spec needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceKind {
+    /// FlatGeoBuf. Windowed (packed Hilbert R-tree); local path or `s3://`.
+    FlatGeoBuf,
+    /// GeoPackage. Load-all by default, windowed when the OGC rtree is present and no
+    /// load-all-only transform was requested.
+    GeoPackage,
+    /// GeoJSON. Load-all; no spatial index.
+    GeoJson,
+    /// A scheme this build does not know how to open. Carried rather than rejected here so the
+    /// CALLER produces the error, with a message naming what it does support. `postgis://` lands
+    /// here until a PostGIS reader exists, which is the intended shape: adding one means adding
+    /// a variant and a match arm, not another `ends_with` somewhere.
+    Unsupported(String),
+}
+
+/// Transport schemes: they say where bytes live, not what they are. Stripped before the format
+/// is classified. `file://` is accepted for symmetry even though a bare path is the norm.
+const TRANSPORT_SCHEMES: [&str; 2] = ["s3", "file"];
+
+/// Split `scheme://rest` into `(scheme, rest)`. `None` when there is no scheme.
+///
+/// Deliberately not a general URI parser: a Windows path (`C:\data\x.fgb`) has a colon but no
+/// `://`, and must not be mistaken for a scheme.
+fn split_scheme(spec: &str) -> Option<(&str, &str)> {
+    let (scheme, rest) = spec.split_once("://")?;
+    if scheme.is_empty()
+        || !scheme
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.')
+    {
+        return None;
+    }
+    Some((scheme, rest))
+}
+
+/// Classify a vector source spec.
+///
+/// Extension matching is case-insensitive: `ROADS.FGB` off a Windows or S3 export is the same
+/// format as `roads.fgb`, and the old `ends_with(".fgb")` silently classified it as GeoPackage
+/// (the fallback arm), which then failed deep inside the SQLite opener with a confusing error.
+/// Any query string is stripped first, so `s3://b/roads.fgb?versionId=…` still classifies.
+pub fn classify(spec: &str) -> SourceKind {
+    let after_transport = match split_scheme(spec) {
+        // A known transport: keep going with the path part, the format is still in the name.
+        Some((scheme, rest))
+            if TRANSPORT_SCHEMES.contains(&scheme.to_ascii_lowercase().as_str()) =>
+        {
+            rest
+        }
+        // An unknown scheme IS the format claim. This is where postgis:// will attach.
+        Some((scheme, _)) => return SourceKind::Unsupported(scheme.to_ascii_lowercase()),
+        None => spec,
+    };
+    let path = after_transport
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(after_transport)
+        .to_ascii_lowercase();
+
+    if path.ends_with(".fgb") {
+        SourceKind::FlatGeoBuf
+    } else if path.ends_with(".geojson") || path.ends_with(".json") {
+        SourceKind::GeoJson
+    } else {
+        // GeoPackage is the historical default for an unrecognised extension, and staying the
+        // default keeps every existing invocation working. `.gpkg` is matched explicitly above
+        // this comment only in spirit: anything unknown still reaches the GeoPackage opener,
+        // which produces its own error if the file is not one.
+        SourceKind::GeoPackage
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify, SourceKind};
+
+    #[test]
+    fn plain_paths_classify_by_extension() {
+        assert_eq!(classify("roads.fgb"), SourceKind::FlatGeoBuf);
+        assert_eq!(classify("/data/cos2023v1.fgb"), SourceKind::FlatGeoBuf);
+        assert_eq!(classify("airports.geojson"), SourceKind::GeoJson);
+        assert_eq!(classify("layers.json"), SourceKind::GeoJson);
+        assert_eq!(classify("/data/bupi.gpkg"), SourceKind::GeoPackage);
+    }
+
+    /// The transport/format split: `s3://` says WHERE, the extension says WHAT. A `.fgb` in a
+    /// bucket is read by the same FlatGeoBuf reader as one on disk.
+    #[test]
+    fn s3_is_a_transport_not_a_format() {
+        assert_eq!(classify("s3://bucket/roads.fgb"), SourceKind::FlatGeoBuf);
+        assert_eq!(classify("s3://bucket/a/b/c.geojson"), SourceKind::GeoJson);
+        assert_eq!(classify("file:///data/x.gpkg"), SourceKind::GeoPackage);
+        assert_eq!(classify("S3://bucket/roads.fgb"), SourceKind::FlatGeoBuf);
+    }
+
+    /// An unknown scheme is a FORMAT claim, and is carried out to the caller rather than being
+    /// silently misread as a GeoPackage path. This is the seam a database source attaches to.
+    #[test]
+    fn unknown_scheme_is_reported_as_a_format_not_guessed_as_a_file() {
+        assert_eq!(
+            classify("postgis://user@host/db?table=roads"),
+            SourceKind::Unsupported("postgis".into())
+        );
+        assert_eq!(
+            classify("POSTGRES://host/db"),
+            SourceKind::Unsupported("postgres".into())
+        );
+    }
+
+    /// Regression: the old `ends_with(".fgb")` was case-SENSITIVE, so an uppercase export fell
+    /// through to the GeoPackage arm and failed inside the SQLite opener with an error naming
+    /// the wrong format entirely.
+    #[test]
+    fn extension_matching_is_case_insensitive() {
+        assert_eq!(classify("ROADS.FGB"), SourceKind::FlatGeoBuf);
+        assert_eq!(classify("Airports.GeoJSON"), SourceKind::GeoJson);
+    }
+
+    /// A query string must not defeat the extension match.
+    #[test]
+    fn query_and_fragment_are_stripped_before_matching() {
+        assert_eq!(
+            classify("s3://b/roads.fgb?versionId=abc123"),
+            SourceKind::FlatGeoBuf
+        );
+        assert_eq!(classify("/data/x.geojson#frag"), SourceKind::GeoJson);
+    }
+
+    /// A Windows path has a colon but no `://`, and must not be read as a scheme.
+    #[test]
+    fn a_windows_path_is_not_a_scheme() {
+        assert_eq!(classify(r"C:\data\roads.fgb"), SourceKind::FlatGeoBuf);
+    }
+
+    /// Unknown EXTENSIONS keep falling through to GeoPackage, which is the historical default
+    /// and what keeps every existing invocation working. Only unknown SCHEMES are rejected.
+    #[test]
+    fn unknown_extension_still_defaults_to_geopackage() {
+        assert_eq!(classify("/data/mystery"), SourceKind::GeoPackage);
+        assert_eq!(classify("/data/thing.sqlite"), SourceKind::GeoPackage);
+    }
+}

--- a/src/wms.rs
+++ b/src/wms.rs
@@ -1283,6 +1283,72 @@ fn hexval(c: u8) -> Option<u8> {
     }
 }
 
+/// Everything from the XML declaration down to the root `<Layer>`'s `<Title>`: the document
+/// header, `<Service>`, `<Request>` and `<Exception>`.
+///
+/// This block was byte-identical in `capabilities` and `capabilities_multi`, which is 50 of
+/// the ~110 lines they shared. Two copies of a conformance-critical preamble is how a CITE
+/// fix gets applied to one document and not the other; the 1.1.1 and 1.3.0 variants differ in
+/// ways (`OGC:WMS` vs `WMS`, `application/vnd.ogc.wms_xml` vs `text/xml`,
+/// `application/vnd.ogc.se_xml` vs `XML`, and GML being a 1.1.1-only GetFeatureInfo format)
+/// that are easy to get subtly wrong twice.
+///
+/// The two generators still differ AFTER this point: the single-layer one emits a fixed inner
+/// `<Layer>`, the multi-layer one emits N of them. Merging those too would mean giving the
+/// single-COG path a `Layer` to describe itself with, which is a caller change, not a
+/// template change, and is deliberately left alone here.
+fn capabilities_preamble(version: &str, service_or: &str, dcp: &str) -> String {
+    if version.starts_with("1.1") {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE WMT_MS_Capabilities SYSTEM "http://schemas.opengis.net/wms/1.1.1/WMS_MS_Capabilities.dtd">
+<WMT_MS_Capabilities version="1.1.1">
+  <Service>
+    <Name>OGC:WMS</Name>
+    <Title>TerraServe WMS</Title>{service_or}
+  </Service>
+  <Capability>
+    <Request>
+      <GetCapabilities><Format>application/vnd.ogc.wms_xml</Format>{dcp}</GetCapabilities>
+      <GetMap><Format>image/png</Format>{dcp}</GetMap>
+      <GetFeatureInfo><Format>text/plain</Format><Format>application/json</Format><Format>text/html</Format><Format>application/vnd.ogc.gml</Format>{dcp}</GetFeatureInfo>
+    </Request>
+    <Exception><Format>application/vnd.ogc.se_xml</Format></Exception>
+    <Layer>
+      <Title>TerraServe</Title>
+"#
+        )
+    } else {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd">
+  <Service>
+    <Name>WMS</Name>
+    <Title>TerraServe WMS</Title>{service_or}
+  </Service>
+  <Capability>
+    <Request>
+      <GetCapabilities><Format>text/xml</Format>{dcp}</GetCapabilities>
+      <GetMap><Format>image/png</Format>{dcp}</GetMap>
+      <GetFeatureInfo><Format>text/plain</Format><Format>application/json</Format><Format>text/html</Format>{dcp}</GetFeatureInfo>
+    </Request>
+    <Exception><Format>XML</Format></Exception>
+    <Layer>
+      <Title>TerraServe</Title>
+"#
+        )
+    }
+}
+
+/// The matching close for `capabilities_preamble`.
+fn capabilities_epilogue(version: &str) -> &'static str {
+    if version.starts_with("1.1") {
+        "    </Layer>\n  </Capability>\n</WMT_MS_Capabilities>\n"
+    } else {
+        "    </Layer>\n  </Capability>\n</WMS_Capabilities>\n"
+    }
+}
+
 fn capabilities(
     version: &str,
     base_url: Option<&str>,
@@ -1310,25 +1376,11 @@ fn capabilities(
     // (no base_url) we fall back to a placeholder href so the document stays schema-valid.
     let (service_or, dcp) = online_resource(base_url);
 
+    let preamble = capabilities_preamble(version, &service_or, &dcp);
+    let epilogue = capabilities_epilogue(version);
     if version.starts_with("1.1") {
         format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE WMT_MS_Capabilities SYSTEM "http://schemas.opengis.net/wms/1.1.1/WMS_MS_Capabilities.dtd">
-<WMT_MS_Capabilities version="1.1.1">
-  <Service>
-    <Name>OGC:WMS</Name>
-    <Title>TerraServe WMS</Title>{service_or}
-  </Service>
-  <Capability>
-    <Request>
-      <GetCapabilities><Format>application/vnd.ogc.wms_xml</Format>{dcp}</GetCapabilities>
-      <GetMap><Format>image/png</Format>{dcp}</GetMap>
-      <GetFeatureInfo><Format>text/plain</Format><Format>application/json</Format><Format>text/html</Format><Format>application/vnd.ogc.gml</Format>{dcp}</GetFeatureInfo>
-    </Request>
-    <Exception><Format>application/vnd.ogc.se_xml</Format></Exception>
-    <Layer>
-      <Title>TerraServe</Title>
-      <SRS>EPSG:4326</SRS>
+            r#"{preamble}      <SRS>EPSG:4326</SRS>
       <SRS>EPSG:3857</SRS>
       <SRS>EPSG:3763</SRS>
       <LatLonBoundingBox minx="{west}" miny="{south}" maxx="{east}" maxy="{north}"/>
@@ -1340,29 +1392,11 @@ fn capabilities(
         <SRS>EPSG:3763</SRS>{extra_srs}
         <LatLonBoundingBox minx="{west}" miny="{south}" maxx="{east}" maxy="{north}"/>
       </Layer>
-    </Layer>
-  </Capability>
-</WMT_MS_Capabilities>
-"#
+{epilogue}"#
         )
     } else {
         format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd">
-  <Service>
-    <Name>WMS</Name>
-    <Title>TerraServe WMS</Title>{service_or}
-  </Service>
-  <Capability>
-    <Request>
-      <GetCapabilities><Format>text/xml</Format>{dcp}</GetCapabilities>
-      <GetMap><Format>image/png</Format>{dcp}</GetMap>
-      <GetFeatureInfo><Format>text/plain</Format><Format>application/json</Format><Format>text/html</Format>{dcp}</GetFeatureInfo>
-    </Request>
-    <Exception><Format>XML</Format></Exception>
-    <Layer>
-      <Title>TerraServe</Title>
-      <CRS>EPSG:4326</CRS>
+            r#"{preamble}      <CRS>EPSG:4326</CRS>
       <CRS>EPSG:3857</CRS>
       <CRS>EPSG:3763</CRS>
       <EX_GeographicBoundingBox>
@@ -1381,10 +1415,7 @@ fn capabilities(
         <BoundingBox CRS="CRS:84" minx="{west}" miny="{south}" maxx="{east}" maxy="{north}"/>
         <BoundingBox CRS="EPSG:4326" minx="{south}" miny="{west}" maxx="{north}" maxy="{east}"/>
       </Layer>
-    </Layer>
-  </Capability>
-</WMS_Capabilities>
-"#
+{epilogue}"#
         )
     }
 }
@@ -1418,6 +1449,8 @@ fn online_resource(base_url: Option<&str>) -> (String, String) {
 /// with its own name, WGS84 bounds, and CRS list (standard + its native CRS).
 fn capabilities_multi(layers: &[Layer], version: &str, base_url: Option<&str>) -> String {
     let (service_or, dcp) = online_resource(base_url);
+    let preamble = capabilities_preamble(version, &service_or, &dcp);
+    let epilogue = capabilities_epilogue(version);
     let is_111 = version.starts_with("1.1");
     let tag = if is_111 { "SRS" } else { "CRS" };
 
@@ -1496,50 +1529,9 @@ fn capabilities_multi(layers: &[Layer], version: &str, base_url: Option<&str>) -
                 })
                 .unwrap_or_default()
         };
-        format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE WMT_MS_Capabilities SYSTEM "http://schemas.opengis.net/wms/1.1.1/WMS_MS_Capabilities.dtd">
-<WMT_MS_Capabilities version="1.1.1">
-  <Service>
-    <Name>OGC:WMS</Name>
-    <Title>TerraServe WMS</Title>{service_or}
-  </Service>
-  <Capability>
-    <Request>
-      <GetCapabilities><Format>application/vnd.ogc.wms_xml</Format>{dcp}</GetCapabilities>
-      <GetMap><Format>image/png</Format>{dcp}</GetMap>
-      <GetFeatureInfo><Format>text/plain</Format><Format>application/json</Format><Format>text/html</Format><Format>application/vnd.ogc.gml</Format>{dcp}</GetFeatureInfo>
-    </Request>
-    <Exception><Format>application/vnd.ogc.se_xml</Format></Exception>
-    <Layer>
-      <Title>TerraServe</Title>
-{top_crs}{root_llbb}{inner}    </Layer>
-  </Capability>
-</WMT_MS_Capabilities>
-"#
-        )
+        format!(r#"{preamble}{top_crs}{root_llbb}{inner}{epilogue}"#)
     } else {
-        format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd">
-  <Service>
-    <Name>WMS</Name>
-    <Title>TerraServe WMS</Title>{service_or}
-  </Service>
-  <Capability>
-    <Request>
-      <GetCapabilities><Format>text/xml</Format>{dcp}</GetCapabilities>
-      <GetMap><Format>image/png</Format>{dcp}</GetMap>
-      <GetFeatureInfo><Format>text/plain</Format><Format>application/json</Format><Format>text/html</Format>{dcp}</GetFeatureInfo>
-    </Request>
-    <Exception><Format>XML</Format></Exception>
-    <Layer>
-      <Title>TerraServe</Title>
-{top_crs}{inner}    </Layer>
-  </Capability>
-</WMS_Capabilities>
-"#
-        )
+        format!(r#"{preamble}{top_crs}{inner}{epilogue}"#)
     }
 }
 
@@ -1651,10 +1643,11 @@ fn exception_with_code(version: &str, code: Option<&str>, message: &str) -> Stri
     }
 }
 
+/// Thin alias for the shared escaper (`crate::xml::escape`), kept so the many call sites in
+/// this file read unchanged. It used to cover only `& < >`, which was unsafe in the two
+/// ATTRIBUTE positions it feeds (`xlink:href=` and `code=`); see `crate::xml`.
 fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
+    crate::xml::escape(s)
 }
 
 /// WMS `BGCOLOR` = `0xRRGGBB` (hex). Absent or malformed -> white (the WMS default). Never errors.
@@ -1681,9 +1674,63 @@ fn parse_transparent(raw: Option<&str>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        first_undefined_layer, handle_layers, json_escape, negotiate_version, parse_bgcolor,
-        parse_transparent,
+        first_undefined_layer, handle_layers, json_escape, negotiate_version, online_resource,
+        parse_bgcolor, parse_transparent, xml_escape,
     };
+
+    /// XML escaping must be safe in ATTRIBUTE position, not just in text position.
+    ///
+    /// Two escapers existed side by side: `wms::xml_escape` covered `& < >`, and
+    /// `wmts::escape_xml` covered `& < > "`. Neither escaped `'`. `wms.rs` called BOTH
+    /// (lines 760/779 reach into `wmts::escape_xml`), and the WEAKER one was the one used to
+    /// build two attribute values: `xlink:href="{href}"` in `online_resource` and
+    /// `code="{...}"` in `exception_with_code`. A value containing a double quote therefore
+    /// closed the attribute early.
+    #[test]
+    fn xml_escape_is_safe_in_attribute_position() {
+        let got = xml_escape(r#"a"b'c&d<e>f"#);
+        assert!(
+            !got.contains('"'),
+            "raw double quote survives escaping: {got}"
+        );
+        assert!(
+            !got.contains('\''),
+            "raw apostrophe survives escaping: {got}"
+        );
+        assert_eq!(got, "a&quot;b&#39;c&amp;d&lt;e&gt;f");
+    }
+
+    /// The concrete consequence, at the call site that actually builds an attribute. A
+    /// `--public-url` containing a quote must not be able to close `xlink:href="` and inject
+    /// further attributes into GetCapabilities.
+    /// NOTE on how this is asserted. An earlier version of this test checked only that
+    /// `<injected` did not appear in the output, and it PASSED against the buggy escaper:
+    /// `<` was already escaped, so no markup was injected, yet the attribute still ended
+    /// early at the raw quote. Absence of markup is the wrong property.
+    ///
+    /// The right property is a ROUND TRIP: read the attribute value the way a parser would
+    /// (up to the next unescaped `"`), unescape it, and require the whole URL back. Under
+    /// the bug the value is truncated at the quote, so this fails.
+    #[test]
+    fn online_resource_href_cannot_break_out_of_its_attribute() {
+        let raw = r#"http://x/"><injected attr="#;
+        let (or, dcp) = online_resource(Some(raw));
+        for frag in [&or, &dcp] {
+            let after = frag.split("xlink:href=\"").nth(1).expect("href attribute");
+            let value = after.split('"').next().expect("attribute value");
+            let unescaped = value
+                .replace("&quot;", "\"")
+                .replace("&#39;", "'")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&amp;", "&");
+            assert_eq!(
+                unescaped,
+                format!("{raw}?"),
+                "attribute value was truncated, so it terminated the attribute early: {frag}"
+            );
+        }
+    }
 
     #[test]
     fn version_negotiation_clamps_to_supported_set() {

--- a/src/wmts.rs
+++ b/src/wmts.rs
@@ -426,11 +426,12 @@ pub fn get_feature_info(
 }
 
 /// XML-escape a dynamic value for interpolation into a document (`&` first).
+/// Thin alias for the shared escaper (`crate::xml::escape`), kept so this module's call
+/// sites (and `wms.rs`, which reaches in here in two places) read unchanged. It used to
+/// cover `& < > "` while `wms::xml_escape` covered only `& < >`; having two that differed
+/// is what let the weaker one end up building an attribute value. See `crate::xml`.
 pub fn escape_xml(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
+    crate::xml::escape(s)
 }
 
 /// An `ows:ExceptionReport` (OWS 1.1). `version="1.1.0"`.
@@ -446,11 +447,13 @@ pub fn exception_xml(code: &str, text: &str, locator: Option<&str>) -> String {
 }
 
 /// Derive `(kvp_base, rest_base)` from the advertised WMS base (`…/wms` → `…/wmts`, `…/wmts/1.0.0`).
-pub fn bases(base_url: &str) -> (String, String) {
-    let origin = base_url
-        .strip_suffix("/wms")
-        .unwrap_or(base_url)
-        .trim_end_matches('/');
+/// The WMTS KVP and RESTful bases, composed on an ALREADY-DERIVED origin.
+///
+/// This used to take `base_url` and derive the origin itself, with logic byte-identical to
+/// `tms_http::tms_root`'s copy, which is why WMTS could not honour `X-Forwarded-Proto`: it
+/// never saw the request. Derivation now lives in exactly one place,
+/// `ServeState::advertised_origin`, and this only appends the paths.
+pub fn bases(origin: &str) -> (String, String) {
     (format!("{origin}/wmts"), format!("{origin}/wmts/1.0.0"))
 }
 

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2026 TerraOps <https://terraops.org>
+
+//! One XML escaper, shared by every protocol front-end.
+//!
+//! There used to be two, and they disagreed. `wms::xml_escape` covered `& < >`;
+//! `wmts::escape_xml` covered `& < > "`. Neither escaped `'`. `wms.rs` called BOTH of them,
+//! reaching into `crate::wmts::escape_xml` in two places while using its own elsewhere.
+//!
+//! That divergence was not cosmetic. The WEAKER escaper was the one building two ATTRIBUTE
+//! values: `xlink:href="{href}"` in `wms::online_resource` (fed by `--public-url`) and
+//! `code="{...}"` in `wms::exception_with_code`. A value containing `"` closed the attribute
+//! early, so the rest of the URL was reinterpreted as further attributes.
+//!
+//! The lesson generalised: a text-position escaper and an attribute-position escaper that
+//! look interchangeable will eventually be swapped by someone who does not know which is
+//! which. Rather than document the distinction, this escapes the full set so BOTH positions
+//! are safe with one function, and there is no second one to pick by mistake.
+//!
+//! `'` is escaped as the numeric `&#39;` rather than `&apos;`: `&apos;` is defined in XML but
+//! NOT in HTML 4, and these documents are routinely parsed by clients using lenient HTML
+//! parsers. The numeric reference is understood by both.
+
+/// Escape a string for XML, safe in both text and attribute position.
+///
+/// `&` must be replaced FIRST, or the ampersands introduced by the later replacements would
+/// themselves be escaped, producing `&amp;lt;` where `&lt;` was meant.
+pub fn escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape;
+
+    #[test]
+    fn escapes_all_five_and_in_the_right_order() {
+        assert_eq!(escape(r#"a&b<c>d"e'f"#), "a&amp;b&lt;c&gt;d&quot;e&#39;f");
+    }
+
+    /// The ordering trap: `&` first. If `<` were replaced before `&`, the `&` of the emitted
+    /// `&lt;` would then be escaped again into `&amp;lt;`.
+    #[test]
+    fn ampersand_is_escaped_before_the_entities_it_would_corrupt() {
+        assert_eq!(escape("<"), "&lt;");
+        assert_eq!(
+            escape("&lt;"),
+            "&amp;lt;",
+            "a literal '&lt;' must survive as text"
+        );
+        assert!(!escape("<").contains("&amp;lt;"));
+    }
+
+    /// Round trip: whatever goes in comes back out of an attribute unchanged. This is the
+    /// property that actually matters at the `xlink:href="..."` call site.
+    #[test]
+    fn attribute_value_round_trips() {
+        for raw in [
+            r#"http://x/"><injected attr="#,
+            "plain",
+            "a'b",
+            "ampersand & more",
+            "",
+        ] {
+            let esc = escape(raw);
+            assert!(!esc.contains('"'), "raw quote left in {esc}");
+            assert!(!esc.contains('\''), "raw apostrophe left in {esc}");
+            let back = esc
+                .replace("&quot;", "\"")
+                .replace("&#39;", "'")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&amp;", "&");
+            assert_eq!(back, raw, "round trip failed for {raw:?}");
+        }
+    }
+
+    #[test]
+    fn leaves_ordinary_text_untouched() {
+        assert_eq!(escape("EPSG:3857"), "EPSG:3857");
+        assert_eq!(escape("cos2023"), "cos2023");
+    }
+}

--- a/tests/mvt_http.rs
+++ b/tests/mvt_http.rs
@@ -196,8 +196,8 @@ fn style_json_prefers_configured_public_url_over_the_request_host() {
     st.public_url = Some("https://terraserve.io/demo/vida/wms".to_string());
     // Host says something else entirely, and there is no X-Forwarded-Proto: the configured
     // public URL must still win, keeping BOTH the https scheme and the /demo/vida prefix.
-    let doc = mvt_http::style_json(&st, LAYER, "WebMercatorQuad", Some("terraserve.io"), None)
-        .unwrap();
+    let doc =
+        mvt_http::style_json(&st, LAYER, "WebMercatorQuad", Some("terraserve.io"), None).unwrap();
     let v: serde_json::Value = serde_json::from_str(&doc).expect("valid JSON");
     assert_eq!(
         v["sources"]["terraserve"]["url"],
@@ -212,8 +212,14 @@ fn style_json_prefers_configured_public_url_over_the_request_host() {
 #[test]
 fn tilejson_takes_the_scheme_from_forwarded_proto() {
     let st = state();
-    let doc = mvt_http::tilejson_doc(&st, LAYER, "WebMercatorQuad", Some("example.org"), Some("https"))
-        .unwrap();
+    let doc = mvt_http::tilejson_doc(
+        &st,
+        LAYER,
+        "WebMercatorQuad",
+        Some("example.org"),
+        Some("https"),
+    )
+    .unwrap();
     let v: serde_json::Value = serde_json::from_str(&doc).expect("valid JSON");
     let tpl = v["tiles"][0].as_str().expect("tiles[0]");
     assert!(
@@ -225,8 +231,14 @@ fn tilejson_takes_the_scheme_from_forwarded_proto() {
 #[test]
 fn style_json_is_a_maplibre_gl_style_referencing_the_source() {
     let st = state();
-    let doc =
-        mvt_http::style_json(&st, LAYER, "WebMercatorQuad", Some("192.168.1.121:8081"), None).unwrap();
+    let doc = mvt_http::style_json(
+        &st,
+        LAYER,
+        "WebMercatorQuad",
+        Some("192.168.1.121:8081"),
+        None,
+    )
+    .unwrap();
     let v: serde_json::Value = serde_json::from_str(&doc).expect("valid JSON");
     assert_eq!(v["version"], 8, "MapLibre GL style spec version");
     // The source references the layer's TileJSON on the REQUEST host (not 0.0.0.0 / base_url).

--- a/tests/mvt_http.rs
+++ b/tests/mvt_http.rs
@@ -147,7 +147,7 @@ fn xyz_tile_raster_layer_is_4xx_not_panic() {
 #[test]
 fn tilejson_document_has_the_expected_shape() {
     let st = state();
-    let doc = mvt_http::tilejson_doc(&st, LAYER, "WebMercatorQuad", None).unwrap();
+    let doc = mvt_http::tilejson_doc(&st, LAYER, "WebMercatorQuad", None, None).unwrap();
     let v: serde_json::Value = serde_json::from_str(&doc).expect("valid JSON");
     assert_eq!(v["tilejson"], "3.0.0");
     let tiles = v["tiles"].as_array().expect("tiles array");
@@ -173,15 +173,60 @@ fn tilejson_document_has_the_expected_shape() {
 #[test]
 fn tilejson_unknown_tms_is_4xx_not_panic() {
     let st = state();
-    let err = mvt_http::tilejson_doc(&st, LAYER, "NoSuchGrid", None).unwrap_err();
+    let err = mvt_http::tilejson_doc(&st, LAYER, "NoSuchGrid", None, None).unwrap_err();
     assert!((400..500).contains(&err.0));
+}
+
+/// Regression for the bug that was LIVE on terraserve.io until 2026-08-03:
+///
+///   GET https://terraserve.io/demo/vida/mvt/vida/style.json
+///     -> "url": "http://terraserve.io/mvt/vida/WebMercatorQuad.json"   (404, mixed-content)
+///
+/// `advertised_origin` preferred the Host header unconditionally, so it hardcoded `http://`
+/// and rebuilt the origin from the host alone, discarding the `/demo/vida` path prefix. Since
+/// HTTP/1.1 ALWAYS sends Host, the configured-`--public-url` branch was dead code.
+///
+/// This asserts at the DOCUMENT level, not on the private helper: the unit tests in
+/// `src/mvt_http.rs` pin `advertised_origin` itself, but only a test that reads the emitted
+/// JSON proves the value actually reaches `sources.terraserve.url`. Both are needed - the
+/// unit tests would still pass if `style_json` stopped calling the helper.
+#[test]
+fn style_json_prefers_configured_public_url_over_the_request_host() {
+    let mut st = state();
+    st.public_url = Some("https://terraserve.io/demo/vida/wms".to_string());
+    // Host says something else entirely, and there is no X-Forwarded-Proto: the configured
+    // public URL must still win, keeping BOTH the https scheme and the /demo/vida prefix.
+    let doc = mvt_http::style_json(&st, LAYER, "WebMercatorQuad", Some("terraserve.io"), None)
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&doc).expect("valid JSON");
+    assert_eq!(
+        v["sources"]["terraserve"]["url"],
+        format!("https://terraserve.io/demo/vida/mvt/{LAYER}/WebMercatorQuad.json"),
+        "configured --public-url must win over the Host header, scheme and path prefix intact"
+    );
+}
+
+/// The other half: with no `--public-url`, the scheme comes from `X-Forwarded-Proto` rather
+/// than being assumed. Traefik terminates TLS, so the connection the server sees is always
+/// plain HTTP and an assumed scheme is always wrong behind a proxy.
+#[test]
+fn tilejson_takes_the_scheme_from_forwarded_proto() {
+    let st = state();
+    let doc = mvt_http::tilejson_doc(&st, LAYER, "WebMercatorQuad", Some("example.org"), Some("https"))
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&doc).expect("valid JSON");
+    let tpl = v["tiles"][0].as_str().expect("tiles[0]");
+    assert!(
+        tpl.starts_with("https://example.org/"),
+        "expected an https origin from X-Forwarded-Proto, got {tpl}"
+    );
 }
 
 #[test]
 fn style_json_is_a_maplibre_gl_style_referencing_the_source() {
     let st = state();
     let doc =
-        mvt_http::style_json(&st, LAYER, "WebMercatorQuad", Some("192.168.1.121:8081")).unwrap();
+        mvt_http::style_json(&st, LAYER, "WebMercatorQuad", Some("192.168.1.121:8081"), None).unwrap();
     let v: serde_json::Value = serde_json::from_str(&doc).expect("valid JSON");
     assert_eq!(v["version"], 8, "MapLibre GL style spec version");
     // The source references the layer's TileJSON on the REQUEST host (not 0.0.0.0 / base_url).
@@ -222,7 +267,7 @@ fn style_json_is_a_maplibre_gl_style_referencing_the_source() {
 #[test]
 fn style_json_unknown_layer_is_404() {
     let st = state();
-    let err = mvt_http::style_json(&st, "nope", "WebMercatorQuad", None).unwrap_err();
+    let err = mvt_http::style_json(&st, "nope", "WebMercatorQuad", None, None).unwrap_err();
     assert_eq!(err.0, 404);
 }
 
@@ -233,7 +278,7 @@ fn style_json_source_url_is_parametrized_by_grid_id() {
     // TileJSON (even though MapLibre itself can only ever render Web Mercator — a client concern,
     // not this server's).
     let st = state();
-    let doc = mvt_http::style_json(&st, LAYER, "WorldCRS84Quad", Some("host:8081")).unwrap();
+    let doc = mvt_http::style_json(&st, LAYER, "WorldCRS84Quad", Some("host:8081"), None).unwrap();
     let v: serde_json::Value = serde_json::from_str(&doc).expect("valid JSON");
     assert_eq!(
         v["sources"]["terraserve"]["url"],

--- a/tests/tms_http.rs
+++ b/tests/tms_http.rs
@@ -66,13 +66,22 @@ fn tilemap_xml_has_bbox_bottom_left_origin_and_tilesets() {
     assert!(xml.contains("href=\"http://h/tms/1.0.0/basemap@WebMercatorQuad/0\""));
 }
 
+/// `tms_root` now COMPOSES on an already-derived origin rather than deriving one itself.
+/// Stripping `/wms` and the trailing slash moved to `ServeState::advertised_origin`, which is
+/// the single derivation shared by WMS, WMTS, TMS and MVT; keeping a private copy here is what
+/// left TMS unable to honour `X-Forwarded-Proto`. The derivation is tested in
+/// `server::advertised_origin_tests`; this only pins the path composition.
 #[test]
-fn tms_root_derives_from_wms_base() {
+fn tms_root_appends_the_service_path_to_an_origin() {
     assert_eq!(
-        tms_http::tms_root("http://localhost:8080/wms"),
+        tms_http::tms_root("http://localhost:8080"),
         "http://localhost:8080/tms/1.0.0"
     );
-    assert_eq!(tms_http::tms_root("http://h/"), "http://h/tms/1.0.0");
+    // A proxied origin carrying a path prefix composes the same way.
+    assert_eq!(
+        tms_http::tms_root("https://terraserve.io/demo/swiss"),
+        "https://terraserve.io/demo/swiss/tms/1.0.0"
+    );
 }
 
 /// Task 2: `GET /tileMatrixSets/{id}` (`tms_http::tile_matrix_set_doc`, the handler's pure-function


### PR DESCRIPTION
Fixes a bug that was **live on terraserve.io** until today.

```
GET https://terraserve.io/demo/vida/mvt/vida/style.json
  -> "url": "http://terraserve.io/mvt/vida/WebMercatorQuad.json"   -> 404
```

Two faults in one line: the scheme was hardcoded to `http://`, which a browser blocks as
mixed content on an HTTPS page, and the origin was rebuilt from the `Host` header alone,
discarding the path prefix the service is mounted under.

### Cause

`advertised_origin()` preferred the `Host` header unconditionally. HTTP/1.1 always sends
`Host`, so the `--public-url` branch below it was effectively dead code, even though
`--public-url` is set for every deployment.

### Fix

An explicitly configured `--public-url` is authoritative: it is the only source carrying
both the public scheme and the path prefix. `ServeState` now keeps it separate from
`base_url`, which otherwise collapses "the operator declared it" and "we defaulted to the
bind address" into one string; that ambiguity was the bug. With no `--public-url` we still
derive from the request, but take the scheme from `X-Forwarded-Proto`, since a
TLS-terminating proxy means the connection the server sees is always plain HTTP.

Also corrects the OCI licence label, which still said `AGPL-3.0-or-later` after the MPL-2.0
relicence. That is the licence a registry displays next to the package.

### Verification

Run in this tree, not inherited from the private one:

- `cargo test` **342/342** (336 existing + 6 new regression tests covering the bug, proxy
  scheme chains, and the unconfigured fallbacks that keep a plain local `serve` working)
- `score.sh` **39/39 required + 2/2 optional**
- `src/` is byte-identical to the private tree

Deployed and confirmed live on all four demos before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fsn3PzqiBJEEcQ6Z9HhvM