### PR TITLE
ci: quote two step names, so the workflow parses and CI can run at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
             || { echo "FAIL: GetCapabilities"; exit 1; }
           echo "ok GetCapabilities"
 
-      - name: Viewers are served (regression: /xray 404'd on any layer not named "vector")
+      - name: 'Viewers are served (regression: /xray 404''d on any layer not named "vector")'
         run: |
           for path in / /xray; do
             code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:8080$path")
@@ -117,7 +117,7 @@ jobs:
             echo "ok $path"
           done
 
-      - name: Advertised tile URLs honour --public-url (regression: shipped http:// + no prefix)
+      - name: 'Advertised tile URLs honour --public-url (regression: shipped http:// + no prefix)'
         run: |
           EXPECT_PREFIX="https://example.org/demo/air"
 


### PR DESCRIPTION
**This repository has had no working CI since 2026-08-03.** Every run has failed in **0 seconds** - including the run on #13 which introduced the workflow, and the one on the engine sync #14 merged today.

`ci.yml` is invalid YAML. Two step names contain an unquoted colon-space:

```yaml
- name: Viewers are served (regression: /xray 404'd on any layer not named "vector")
- name: Advertised tile URLs honour --public-url (regression: shipped http:// + no prefix)
```

YAML reads `name: Viewers are served (regression` and then hits `: /xray` - *mapping values are not allowed here*, line 112 column 45. Both names are now quoted. **Two-line diff.**

### Why it went unnoticed for twelve days

GitHub reports a workflow-level parse error as a red X with **"This run likely failed because of a workflow file issue"**, no logs and no job list. Beside a normal test failure it reads like a flaky runner; the 0-second duration is the only real tell.

### Verified

All three workflow files parse, and `ci.yml` resolves to `build-test` + `smoke`. Both were observed **passing** on the branch this was split from - which also means the engine sync merged earlier today is now genuinely verified by CI, not just locally.

### Scope

A Windows build job was originally part of this change and is **split into its own PR**. Getting  green on MSVC has taken four rounds so far (invalid YAML, then CMake 4 rejecting PROJ's pre-3.5 minimum, then vendored PROJ needing SQLite3, now a `PKG_CONFIG_PATH` that does not survive into the build). Having CI at all is the bigger win and should not wait for it.