### PR TITLE
chore: v0.2.0, and make positional file reads work on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "terraserve"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terraserve"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MPL-2.0"
 description = "Clean-room raster + vector tile engine in Rust (COG / GeoPackage / FlatGeoBuf → WMS / WMTS / TMS / MVT), no GDAL / MapServer / GeoServer."

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "terraserve-py"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "pyo3",
  "terraserve",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 [package]
 name = "terraserve-py"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MPL-2.0"
 description = "Python bindings for the TerraServe raster map engine (COG → PNG)."

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "terraserve"
-version = "0.1.0"
+version = "0.2.0"
 description = "TerraServe raster map rendering (COG → PNG) + a pygeoapi OGC API - Maps provider."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/cog.rs
+++ b/src/cog.rs
@@ -11,7 +11,8 @@
 //! transparency. The source CRS is given (EPSG:3763) — no GeoKey CRS decoding needed.
 
 use std::fs::File;
-use std::os::unix::fs::FileExt;
+// Positional reads go through `pread`, which works on Windows too (issue #9).
+use crate::pread::read_exact_at;
 
 /// GRADED SEAM: every COG byte read flows through this trait. The pilot ships
 /// `LocalFileRangeSource`; the S3 impl (`s3::S3RangeSource`) reads over signed HTTP ranges.
@@ -38,7 +39,7 @@ impl LocalFileRangeSource {
 impl RangeSource for LocalFileRangeSource {
     fn read_range(&self, offset: u64, len: usize) -> std::io::Result<Vec<u8>> {
         let mut buf = vec![0u8; len];
-        self.file.read_exact_at(&mut buf, offset)?;
+        read_exact_at(&self.file, &mut buf, offset)?;
         Ok(buf)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod layer;
 pub mod legend;
 pub mod mvt_http;
 pub mod pngio;
+pub mod pread;
 pub mod render;
 pub mod reproj;
 pub mod s3;

--- a/src/pread.rs
+++ b/src/pread.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2026 TerraOps <https://terraops.org>
+
+//! Positional file reads, on every platform.
+//!
+//! The engine reads files at explicit offsets from many threads at once: `cog.rs` pulls TIFF tiles
+//! out of a COG, and `pmtiles/overlay.rs` reads its append-only log while writers append to it.
+//! Both did this with `std::os::unix::fs::FileExt::read_exact_at`, which does not exist on Windows,
+//! so the crate simply did not compile there (`cannot find 'unix' in 'os'`). That is half of
+//! terraops-org/TerraServe#9; the other half was jemalloc.
+//!
+//! The property both call sites depend on is that the read takes its offset as an ARGUMENT and does
+//! not depend on a shared file cursor - otherwise two threads reading different tiles would race on
+//! `seek`. This module preserves exactly that on both platforms and nothing more.
+
+use std::fs::File;
+use std::io;
+
+/// Read exactly `buf.len()` bytes starting at `offset`, without using or disturbing a shared file
+/// cursor. Errors if the file ends first - a short read is an error, never a zero-padded buffer.
+///
+/// Unix uses `pread` via `FileExt::read_exact_at`. Windows uses `FileExt::seek_read`, which is also
+/// positional (it passes the offset through an `OVERLAPPED`), and loops because it is permitted to
+/// return a short read. `seek_read` does additionally move the file pointer as a side effect, which
+/// is harmless here precisely because every caller passes an explicit offset and none of them ever
+/// reads from the current position.
+pub fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileExt;
+        file.read_exact_at(buf, offset)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::FileExt;
+        let mut done = 0usize;
+        while done < buf.len() {
+            match file.seek_read(&mut buf[done..], offset + done as u64) {
+                // A zero-length read at a non-EOF offset would spin forever, so treat it the same
+                // way `read_exact` does: the file ended early.
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "failed to fill whole buffer",
+                    ))
+                }
+                Ok(n) => done += n,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (file, buf, offset);
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "positional file reads are not implemented for this platform",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_exact_at;
+    use std::io::Write;
+
+    fn temp_file(bytes: &[u8]) -> (std::path::PathBuf, std::fs::File) {
+        let p = std::env::temp_dir().join(format!(
+            "ts_pread_{}_{}.bin",
+            std::process::id(),
+            bytes.len()
+        ));
+        let mut w = std::fs::File::create(&p).unwrap();
+        w.write_all(bytes).unwrap();
+        w.sync_all().unwrap();
+        let r = std::fs::File::open(&p).unwrap();
+        (p, r)
+    }
+
+    #[test]
+    fn reads_at_an_offset_without_moving_a_cursor() {
+        let (p, f) = temp_file(b"0123456789");
+        let mut a = [0u8; 3];
+        let mut b = [0u8; 3];
+        // Read the LATER range first: if this used a shared cursor, the second read would return
+        // the bytes after it rather than the ones asked for.
+        read_exact_at(&f, &mut a, 6).unwrap();
+        read_exact_at(&f, &mut b, 1).unwrap();
+        assert_eq!(&a, b"678");
+        assert_eq!(&b, b"123");
+        // And repeating a read gives the same bytes, which a cursor-based read would not.
+        let mut again = [0u8; 3];
+        read_exact_at(&f, &mut again, 6).unwrap();
+        assert_eq!(&again, b"678");
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[test]
+    fn a_short_read_is_an_error_not_a_padded_buffer() {
+        // The overlay reader depends on this: a truncated log must fail loudly rather than hand
+        // back zeros that decode as an empty tile.
+        let (p, f) = temp_file(b"abc");
+        let mut buf = [0u8; 8];
+        let err = read_exact_at(&f, &mut buf, 0).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[test]
+    fn reading_entirely_past_the_end_errors() {
+        let (p, f) = temp_file(b"abc");
+        let mut buf = [0u8; 2];
+        assert!(read_exact_at(&f, &mut buf, 99).is_err());
+        let _ = std::fs::remove_file(p);
+    }
+}

--- a/src/vector/pmtiles/overlay.rs
+++ b/src/vector/pmtiles/overlay.rs
@@ -14,7 +14,8 @@ use crate::vector::pmtiles::PmResult;
 use std::collections::{BTreeSet, HashMap};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
-use std::os::unix::fs::FileExt;
+// Positional reads go through `pread`, which works on Windows too (issue #9).
+use crate::pread::read_exact_at;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -235,8 +236,7 @@ impl TileOverlay {
             }
         };
         let mut buf = vec![0u8; len as usize];
-        self.log_r
-            .read_exact_at(&mut buf, off)
+        read_exact_at(&self.log_r, &mut buf, off)
             .map_err(|e| format!("overlay read_exact_at: {e}"))?;
         Ok(Some(gunzip(&buf)?))
     }
@@ -251,8 +251,7 @@ impl TileOverlay {
             }
         };
         let mut buf = vec![0u8; len as usize];
-        self.log_r
-            .read_exact_at(&mut buf, off)
+        read_exact_at(&self.log_r, &mut buf, off)
             .map_err(|e| format!("overlay read_exact_at: {e}"))?;
         Ok(Some(buf))
     }


### PR DESCRIPTION
**Merge this before tagging `v0.2.0`.** Two things the release needs.

## 1. The version still said 0.1.0

`Cargo.toml`, `bindings/python/Cargo.toml` and `bindings/python/pyproject.toml` all declared **0.1.0**, and both lockfiles recorded it. Tagging `v0.2.0` over that would have published a wheel named **terraserve-0.1.0** from a tag claiming 0.2.0 - and `v0.1.0` already exists, so the artifacts would have **collided with the previous release**. All five places now say 0.2.0 and the binary reports `terraserve 0.2.0`.

0.2.0 rather than 0.1.1 because this is a minor bump by any reading: a PostGIS vector source, projection-generic tile grids including the OGC `EuropeanETRS89_LAEAQuad`, raster PMTiles, and two new CLI flags.

## 2. Windows: the other half of #9

With jemalloc excluded on MSVC, the Windows build gets as far as compiling TerraServe itself and then dies:

```
error[E0433]: cannot find `unix` in `os`
error[E0599]: no method named `read_exact_at` found for struct `File`
```

`cog.rs` and `pmtiles/overlay.rs` both imported `std::os::unix::fs::FileExt` to read at an explicit offset. `src/pread.rs` now provides one `read_exact_at(&File, &mut [u8], offset)` for both platforms: `pread` on Unix, `seek_read` on Windows - looped, because Windows may return a short read, and treating a zero-length read as EOF so a truncated file cannot spin forever.

The property both call sites depend on is that **the offset is an argument, not a shared cursor**: `cog.rs` reads TIFF tiles from many threads at once, and `overlay.rs` reads its append-only log while writers append to it. `seek_read` is positional in the same sense; it *does* also move the file pointer as a side effect, which is harmless here only because no caller ever reads from the current position. That reasoning is written at the function, because it is exactly what a future edit could quietly break.

Tests pin the two properties that matter, not just "it reads bytes": reading a **later** range before an earlier one still returns the right bytes (a cursor-based implementation fails this), and a short read is an **error**, never a zero-padded buffer - the overlay reader depends on that, or a truncated log decodes as an empty tile behind a success.

## Verified from this tree

| | |
|---|---|
| `cargo test` | 60 binaries, 0 failures |
| `./score.sh` | 39/39 + 2/2 |
| `terraserve --version` | `terraserve 0.2.0` |
| `cargo metadata --filter-platform x86_64-pc-windows-msvc` | no jemalloc |

Whether Windows compiles **end to end** is for CI to say - it is the one thing this machine cannot check. The Windows CI job itself is #15, still WIP and not blocking; this PR fixes the engine-side portability regardless.