### PR TITLE
fix(test): pread's temp files raced each other (main is RED, do not tag until this lands)

### DIFF
--- a/src/pread.rs
+++ b/src/pread.rs
@@ -66,11 +66,17 @@ mod tests {
     use super::read_exact_at;
     use std::io::Write;
 
+    /// ⚠ The name must be unique PER CALL, not per content. Naming it after `bytes.len()` meant
+    /// the two tests that both use `b"abc"` shared one path, ran in parallel, and deleted the file
+    /// from under each other - a race that passed locally on timing luck and failed in CI with a
+    /// bare `NotFound`. An atomic counter is what the GPKG windowed tests already use.
     fn temp_file(bytes: &[u8]) -> (std::path::PathBuf, std::fs::File) {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static N: AtomicU32 = AtomicU32::new(0);
         let p = std::env::temp_dir().join(format!(
             "ts_pread_{}_{}.bin",
             std::process::id(),
-            bytes.len()
+            N.fetch_add(1, Ordering::Relaxed)
         ));
         let mut w = std::fs::File::create(&p).unwrap();
         w.write_all(bytes).unwrap();


### PR DESCRIPTION
**`main` is currently red and must not be tagged `v0.2.0` until this merges.** Seven-line diff.

`temp_file` in `src/pread.rs`'s test module named its file after `bytes.len()`, so the two tests that both use `b"abc"` - `a_short_read_is_an_error_not_a_padded_buffer` and `reading_entirely_past_the_end_errors` - shared a single path. Cargo runs tests in parallel and each deletes the file when it finishes, so one removed it from under the other.

It surfaced as a bare `NotFound` from the `File::open` inside the helper, several frames away from anything that looks like a test-isolation problem:

```
---- pread::tests::reading_entirely_past_the_end_errors stdout ----
thread '...' panicked at src/pread.rs:78:41:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound }
```

Fixed with an atomic per-call counter - the pattern the GPKG windowed tests already use for exactly this. **The shim itself was never wrong**; only my test harness for it. The Windows portability fix in #17 stands.

### Worth noting

This passed on my machine on every run, including five consecutive ones, and failed on the **first CI run of main**. A timing-dependent test is precisely the kind local passes cannot vouch for - and this is the first time this repository has had CI able to say so, since it only started working today. It caught a real defect within hours.