### PR TITLE
fix(deps): proj-sys 0.26 (PROJ 9.6.0), not 0.27 - 0.27 breaks the image build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "proj"
-version = "0.31.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10730bc2a73edc2eb5673204b51d5459eae92a87c813cb6267c64066cbce9de2"
+checksum = "58e0c01de214d7ea50ee6519969be9efdc6f0dc5ce6c64fbd4f054ea26d43ca4"
 dependencies = [
  "geo-types",
  "libc",
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "proj-sys"
-version = "0.27.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ffa255a853264169516c9fc21f524446aca5b091daab6052f2a9b3e5e90359"
+checksum = "a208129995443a4c475464c33308274be1578993b0ad266c9139188ed0dc7e91"
 dependencies = [
  "cmake",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_support
 clap = { version = "4", features = ["derive"] }
 flate2 = "1"
 png = "0.17"
-proj = "0.31"
+proj = "0.30"
 # Direct FFI to a handful of libproj C functions (proj_create/proj_as_proj_string) not
 # exposed by the `proj` crate's safe wrapper — needed to export an arbitrary CRS as a
 # PROJ.4 string for the viewer's proj4js registration (see reproj::crs_to_proj4). Pinned to
@@ -65,7 +65,7 @@ proj = "0.31"
 # unifies it into the same build — no second libproj, no second `links = "proj"` conflict.
 # Its own `bundled_proj` feature is NOT enabled here; `proj/bundled_proj` (below) remains
 # the sole switch, so the Python wheel's vendored-PROJ build is untouched.
-proj-sys = "=0.27.0"
+proj-sys = "=0.26.0"
 weezl = "0.1"   # LZW codec (TIFF variant) — a codec crate like flate2/zune-jpeg, not a TIFF reader
 zune-jpeg = "0.4"
 zstd = "0.13"   # ZSTD codec (libzstd binding) — a codec crate like flate2/zune-jpeg, not a TIFF reader


### PR DESCRIPTION
The recut `v0.2.0` **image** build failed (the wheel fix in #19 was right, but its dependency choice was one version too far):

```
Package 'proj' has version '9.6.0', required version is '>= 9.6.2'
building libproj from source
is `cmake` not installed?
```

`proj-sys 0.27` requires PROJ **>= 9.6.2**; Debian trixie ships **9.6.0**. pkg-config failed, proj-sys fell back to compiling PROJ from source, and the builder image has no cmake.

That fallback also **contradicts the image's stated design** - the Dockerfile links OS-packaged libproj dynamically and the runtime stage installs `libproj25` for exactly that purpose. A source build makes that package dead weight and adds a C++ compile to every architecture of a multi-arch build.

### `proj-sys 0.26.0` fits exactly

| version | requires | vendors | symbol in `proj.h` | PROJ CMake floor |
|---|---|---|---|---|
| 0.23.2 (before) | 9.2.0 | 9.2.1 | ✗ experimental | pre-3.5 ✗ |
| **0.26.0 (this)** | **9.6.0** | **9.6.0** | ✓ | 3.16 ✓ |
| 0.27.0 (#19) | 9.6.2 | 9.6.2 | ✓ | 3.16 ✓ |

9.6.0 is what trixie ships, so **no Dockerfile change and no chasing 9.6.2 into the base image**. The `extern "C"` workaround stays deleted, since 9.6.0 declares the function in `proj.h`.

### Verified - checking *which* path ran, not just that it built

| | |
|---|---|
| system libproj | `ldd` shows `libproj.so.25` - **dynamically linked**, not source-built |
| `--features bundled-proj`, no `CMAKE_POLICY_VERSION_MINIMUM` | ✅ the wheel path |
| `cargo test` / `./score.sh` | 60 binaries / 39/39 + 2/2 |
| Swiss LV95 datum tests | ✅ still pass |

That distinction matters because I got it wrong once: when I called the 0.27 upgrade "verified on system libproj", **this box is also 9.6.0**, so proj-sys had silently source-built here too. `Finished` says nothing about which path was taken - `ldd` does.